### PR TITLE
EDX-4373 Add base error into go-mod-edge-utils

### DIFF
--- a/pkg/errors/base.go
+++ b/pkg/errors/base.go
@@ -1,0 +1,146 @@
+// Copyright (C) 2023 IOTech Ltd
+
+package errors
+
+import (
+	"errors"
+	"fmt"
+	"runtime"
+)
+
+// BaseError generalizes an error structure which can be used for any type of error
+type BaseError struct {
+	// wrappedErr is a nested error which is used to form a chain of errors for better context
+	wrappedErr error
+	// kind contains information regarding the error type
+	kind ErrKind
+	// message contains detailed information about the error.
+	message string
+	// callerInfo contains information of function call stacks when this BaseError is invoked.
+	callerInfo string
+	// extensions contains extra information regarding the error
+	details ErrDetails
+}
+
+// Error implements the Error interface for the BaseError struct
+func (be BaseError) Error() string {
+	if be.wrappedErr == nil {
+		return be.message
+	}
+
+	// be.wrappedErr.Error functionality gets the error message of the wrapped error and which will handle both CommonEdgeX
+	// types and Go standard errors(both wrapped and non-wrapped).
+	if be.message != "" {
+		return be.message + " -> " + be.wrappedErr.Error()
+	} else {
+		return be.wrappedErr.Error()
+	}
+}
+
+// Message returns the first level error message without further details.
+func (be BaseError) Message() string {
+	if be.message == "" && be.wrappedErr != nil {
+		if w, ok := be.wrappedErr.(BaseError); ok {
+			return w.Message()
+		} else {
+			return be.wrappedErr.Error()
+		}
+	}
+
+	return be.message
+}
+
+// DebugMessages returns a string taking all nested and wrapped operations and errors into account.
+func (be BaseError) DebugMessages() string {
+	if be.wrappedErr == nil {
+		return be.callerInfo + ": " + be.message
+	}
+
+	if w, ok := be.wrappedErr.(BaseError); ok {
+		return be.callerInfo + ": " + be.message + " -> " + w.DebugMessages()
+	} else {
+		return be.callerInfo + ": " + be.message + " -> " + be.wrappedErr.Error()
+	}
+}
+
+// Kind returns the error kind of this BaseError.
+func (be BaseError) Kind() ErrKind {
+	return be.kind
+}
+
+// Details returns the detail maps of this BaseError.
+func (be BaseError) Details() ErrDetails {
+	return be.details
+}
+
+// AddDetail adds a detail associated with key for this BaseError.
+func (be BaseError) AddDetail(key string, detail any) {
+	if be.details == nil {
+		be.details = make(ErrDetails)
+	}
+	be.details[key] = detail
+}
+
+// Unwrap retrieves the next nested error in the wrapped error chain.
+// This is used by the new wrapping and unwrapping features available in Go 1.13 and aids in traversing the error chain
+// of wrapped errors.
+func (be BaseError) Unwrap() error {
+	return be.wrappedErr
+}
+
+// Is determines if an error is of type BaseError.
+// This is used by the new wrapping and unwrapping features available in Go 1.13 and aids the errors.Is function when
+// determining is an error or any error in the wrapped chain contains an error of a particular type.
+func (be BaseError) Is(err error) bool {
+	var baseError BaseError
+	switch {
+	case errors.As(err, &baseError):
+		return true
+	default:
+		return false
+	}
+}
+
+// Kind determines the Kind associated with an error by inspecting the chain of errors. The first non-KindUnknown Kind
+// found from the chain of wrappedErr is returned.  If Kind cannot be determined from wrappedErr, KindUnknown is returned
+func Kind(err error) ErrKind {
+	var e BaseError
+	if !errors.As(err, &e) {
+		return KindUnknown
+	}
+	// We want to return the first "Kind" we see that isn't Unknown, because
+	// the higher in the stack the Kind was specified the more context we had.
+	if e.kind != KindUnknown || e.wrappedErr == nil {
+		return e.kind
+	}
+	return Kind(e.wrappedErr)
+}
+
+// NewBaseError creates a new BaseError with the information provided
+func NewBaseError(kind ErrKind, errMsg string, err error, detail ErrDetails) BaseError {
+	return BaseError{
+		kind:       kind,
+		message:    errMsg,
+		wrappedErr: err,
+		callerInfo: getCallerInformation(),
+		details:    detail,
+	}
+}
+
+// ToBaseError creates a new BaseError with Kind found from err
+func ToBaseError(err error) BaseError {
+	kind := Kind(err)
+	return NewBaseError(kind, "", err, nil)
+}
+
+// getCallerInformation generates information about the caller function. This function skips the caller which has
+// invoked this function, but rather introspects the calling function 3 frames below this frame in the call stack. This
+// function is a helper function which eliminates the need for the 'callerInfo' field in the `CommonEdgeX` type and
+// providing an 'callerInfo' string when creating an 'CommonEdgeX'
+func getCallerInformation() string {
+	pc := make([]uintptr, 10)
+	runtime.Callers(3, pc)
+	f := runtime.FuncForPC(pc[0])
+	file, line := f.FileLine(pc[0])
+	return fmt.Sprintf("[%s]-%s(line %d)", file, f.Name(), line)
+}

--- a/pkg/errors/base_test.go
+++ b/pkg/errors/base_test.go
@@ -1,0 +1,90 @@
+// Copyright (C) 2023 IOTech Ltd
+
+package errors
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+var (
+	L0Error        = NewBaseError(KindUnknown, "", nil, nil)
+	L1Error        = fmt.Errorf("nothing")
+	L1ErrorWrapper = ToBaseError(L1Error)
+	L2ErrorWrapper = ToBaseError(L1ErrorWrapper)
+	L2Error        = NewBaseError(KindDatabaseError, "database failed", L1Error, nil)
+	L3Error        = ToBaseError(L2Error)
+	L4Error        = NewBaseError(KindUnknown, "don't know", L3Error, nil)
+	L5Error        = NewBaseError(KindCommunicationError, "network disconnected", L4Error, nil)
+)
+
+func TestKind(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		kind ErrKind
+	}{
+		{"Check the empty BaseError", L0Error, KindUnknown},
+		{"Check the non-BaseError", L1Error, KindUnknown},
+		{"Get the first error kind with 1 error wrapped", L2Error, KindDatabaseError},
+		{"Get the first error kind with 2 error wrapped", L3Error, KindDatabaseError},
+		{"Get the first non-unknown error kind with 3 error wrapped", L4Error, KindDatabaseError},
+		{"Get the first error kind with 4 error wrapped", L5Error, KindCommunicationError},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			k := Kind(tt.err)
+			assert.Equal(t, tt.kind, k, fmt.Sprintf("Retrieved Error Kind %s is not equal to %s.", k, tt.kind))
+		})
+	}
+}
+
+func TestMessage(t *testing.T) {
+	tests := []struct {
+		name string
+		err  Error
+		msg  string
+	}{
+		{"Get the first level error message from an empty error", L0Error, ""},
+		{"Get the first level error message from an empty Error with 1 error wrapped", L1ErrorWrapper, L1Error.Error()},
+		{"Get the first level error message from an empty Error with 1 empty error wrapped", L2ErrorWrapper, L1Error.Error()},
+		{"Get the first level error message from an Error with 1 error wrapped", L2Error, L2Error.message},
+		{"Get the first level error message from an empty Error with 2 error wrapped", L3Error, L2Error.message},
+		{"Get the first level error message from an Error with 3 error wrapped", L4Error, L4Error.message},
+		{"Get the first level error message from an Error with 4 error wrapped", L5Error, L5Error.message},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := tt.err.Message()
+			assert.Equal(t, tt.msg, m, fmt.Sprintf("Returned error message %s is not equal to %s.", m, tt.msg))
+		})
+	}
+}
+
+func TestError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  Error
+		msgs []string
+	}{
+		{"Get the chained error message from an empty error", L0Error, []string{""}},
+		{"Get the chained error message from an empty Error with 1 error wrapped", L1ErrorWrapper, []string{L1Error.Error()}},
+		{"Get the chained error message from an empty Error with 1 empty error wrapped", L2ErrorWrapper, []string{L1Error.Error()}},
+		{"Get the chained error message from an Error with 1 error wrapped", L2Error, []string{L2Error.message, L1Error.Error()}},
+		{"Get the chained error message from an empty Error with 2 error wrapped", L3Error, []string{L2Error.message, L1Error.Error()}},
+		{"Get the chained error message from an Error with 3 error wrapped", L4Error, []string{L4Error.message, L2Error.message, L1Error.Error()}},
+		{"Get the chained error message from an Error with 4 error wrapped", L5Error, []string{L5Error.message, L4Error.message, L2Error.message, L1Error.Error()}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := tt.err.Error()
+			for _, msg := range tt.msgs {
+				assert.Contains(t, m, msg, fmt.Sprintf("Returned error message %s doesn't contain %s.", m, msg))
+			}
+		})
+	}
+}

--- a/pkg/errors/http.go
+++ b/pkg/errors/http.go
@@ -1,0 +1,92 @@
+// Copyright (C) 2023 IOTech Ltd
+
+package errors
+
+import (
+	"fmt"
+	"net/http"
+)
+
+type HTTPError struct {
+	BaseError
+	httpStatusCode int
+}
+
+func NewHTTPError(wrappedError error) HTTPError {
+	kind := Kind(wrappedError)
+	baseError := NewBaseError(kind, "", wrappedError, nil)
+	return HTTPError{
+		BaseError:      baseError,
+		httpStatusCode: codeMapping(kind),
+	}
+}
+
+func (he HTTPError) Message() string {
+	return fmt.Sprintf("%s(status code:%d)", he.BaseError.Message(), he.httpStatusCode)
+}
+
+// codeMapping determines the correct HTTP response code for the given error kind.
+func codeMapping(kind ErrKind) int {
+	switch kind {
+	case KindUnknown, KindDatabaseError, KindServerError, KindOverflowError, KindNaNError:
+		return http.StatusInternalServerError
+	case KindCommunicationError:
+		return http.StatusBadGateway
+	case KindEntityDoesNotExist:
+		return http.StatusNotFound
+	case KindContractInvalid, KindInvalidId:
+		return http.StatusBadRequest
+	case KindStatusConflict, KindDuplicateName:
+		return http.StatusConflict
+	case KindLimitExceeded:
+		return http.StatusRequestEntityTooLarge
+	case KindServiceUnavailable:
+		return http.StatusServiceUnavailable
+	case KindServiceLocked:
+		return http.StatusLocked
+	case KindNotImplemented:
+		return http.StatusNotImplemented
+	case KindNotAllowed:
+		return http.StatusMethodNotAllowed
+	case KindRangeNotSatisfiable:
+		return http.StatusRequestedRangeNotSatisfiable
+	case KindIOError:
+		return http.StatusForbidden
+	case KindUnauthorized:
+		return http.StatusUnauthorized
+	default:
+		return http.StatusInternalServerError
+	}
+}
+
+// KindMapping determines the correct EdgeX error kind for the given HTTP response code.
+func KindMapping(code int) ErrKind {
+	switch code {
+	case http.StatusInternalServerError:
+		return KindServerError
+	case http.StatusBadGateway:
+		return KindCommunicationError
+	case http.StatusNotFound:
+		return KindEntityDoesNotExist
+	case http.StatusBadRequest:
+		return KindContractInvalid
+	case http.StatusConflict:
+		return KindStatusConflict
+	case http.StatusRequestEntityTooLarge:
+		return KindLimitExceeded
+	case http.StatusServiceUnavailable:
+		return KindServiceUnavailable
+	case http.StatusLocked:
+		return KindServiceLocked
+	case http.StatusNotImplemented:
+		return KindNotImplemented
+	case http.StatusMethodNotAllowed:
+		return KindNotAllowed
+	case http.StatusRequestedRangeNotSatisfiable:
+		return KindRangeNotSatisfiable
+	case http.StatusUnauthorized:
+		return KindUnauthorized
+	default:
+		return KindUnknown
+	}
+}

--- a/pkg/errors/http_test.go
+++ b/pkg/errors/http_test.go
@@ -1,0 +1,63 @@
+// Copyright (C) 2023 IOTech Ltd
+
+package errors
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"net/http"
+	"strconv"
+	"testing"
+)
+
+func TestHttpError(t *testing.T) {
+	tests := []struct {
+		name       string
+		wrappedErr error
+		kind       ErrKind
+		errMsg     string
+	}{
+		{"Wrapped error is go error", fmt.Errorf("go base error"), KindUnknown, ""},
+		{"Wrapped error is BaseError", ToBaseError(fmt.Errorf("base error")), KindCommunicationError, "communication base error"},
+		{"Wrapped error is BaseError with 4 error wrapped", L5Error, KindAuthenticationFailure, "http authentication failure"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			baseErr := NewBaseError(tt.kind, tt.errMsg, nil, nil)
+			httpErr := NewHTTPError(baseErr)
+			expectedCode := codeMapping(tt.kind)
+			assert.Equal(t, httpErr.httpStatusCode, expectedCode, fmt.Sprintf("Retrieved http status code %v is not equal to %v.", httpErr.httpStatusCode, expectedCode))
+			assert.Contains(t, httpErr.Message(), strconv.Itoa(expectedCode), fmt.Sprintf("Retrieved http error message %v doesn't contain %v.", httpErr.Message(), expectedCode))
+			assert.Equal(t, httpErr.Kind(), tt.kind, fmt.Sprintf("Retrieved http error kind %v is not equal to %v.", httpErr.Kind(), tt.kind))
+		})
+	}
+}
+
+func TestKindMapping(t *testing.T) {
+	tests := []struct {
+		name           string
+		httpStatusCode int
+	}{
+		{fmt.Sprintf("status code: %d", http.StatusInternalServerError), http.StatusInternalServerError},
+		{fmt.Sprintf("status code: %d", http.StatusBadGateway), http.StatusBadGateway},
+		{fmt.Sprintf("status code: %d", http.StatusNotFound), http.StatusNotFound},
+		{fmt.Sprintf("status code: %d", http.StatusBadRequest), http.StatusBadRequest},
+		{fmt.Sprintf("status code: %d", http.StatusConflict), http.StatusConflict},
+		{fmt.Sprintf("status code: %d", http.StatusRequestEntityTooLarge), http.StatusRequestEntityTooLarge},
+		{fmt.Sprintf("status code: %d", http.StatusServiceUnavailable), http.StatusServiceUnavailable},
+		{fmt.Sprintf("status code: %d", http.StatusLocked), http.StatusLocked},
+		{fmt.Sprintf("status code: %d", http.StatusNotImplemented), http.StatusNotImplemented},
+		{fmt.Sprintf("status code: %d", http.StatusMethodNotAllowed), http.StatusMethodNotAllowed},
+		{fmt.Sprintf("status code: %d", http.StatusRequestedRangeNotSatisfiable), http.StatusRequestedRangeNotSatisfiable},
+		{fmt.Sprintf("status code: %d", http.StatusUnauthorized), http.StatusUnauthorized},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			kind := KindMapping(tt.httpStatusCode)
+			code := codeMapping(kind)
+			assert.Equal(t, tt.httpStatusCode, code, fmt.Sprintf("Retrieved http status code %v is not equal to %v.", tt.httpStatusCode, code))
+		})
+	}
+}

--- a/pkg/errors/types.go
+++ b/pkg/errors/types.go
@@ -1,0 +1,50 @@
+// Copyright (C) 2023 IOTech Ltd
+
+package errors
+
+// ErrKind a categorical identifier used to give high-level insight as to the error type.
+type ErrKind string
+
+const (
+	// Constant Kind identifiers which can be used to label and group errors.
+	KindUnknown               ErrKind = "Unknown"
+	KindDatabaseError         ErrKind = "Database"
+	KindCommunicationError    ErrKind = "Communication"
+	KindEntityDoesNotExist    ErrKind = "NotFound"
+	KindContractInvalid       ErrKind = "ContractInvalid"
+	KindServerError           ErrKind = "UnexpectedServerError"
+	KindLimitExceeded         ErrKind = "LimitExceeded"
+	KindStatusConflict        ErrKind = "StatusConflict"
+	KindDuplicateName         ErrKind = "DuplicateName"
+	KindInvalidId             ErrKind = "InvalidId"
+	KindServiceUnavailable    ErrKind = "ServiceUnavailable"
+	KindNotAllowed            ErrKind = "NotAllowed"
+	KindServiceLocked         ErrKind = "ServiceLocked"
+	KindNotImplemented        ErrKind = "NotImplemented"
+	KindRangeNotSatisfiable   ErrKind = "RangeNotSatisfiable"
+	KindIOError               ErrKind = "IOError"
+	KindOverflowError         ErrKind = "OverflowError"
+	KindNaNError              ErrKind = "NaNError"
+	KindUnauthorized          ErrKind = "Unauthorized"
+	KindAuthenticationFailure ErrKind = "AuthenticationFailure"
+	KindPayloadDecodeFailure  ErrKind = "PayloadDecodeFailure"
+)
+
+// ErrDetails is a detailed mapping to set extra information with the error
+type ErrDetails map[string]any
+
+// Error provides an abstraction for all internal errors.
+// This exists so that we can use this type in our method signatures and return nil which will fit better with the way
+// the Go builtin errors are normally handled.
+type Error interface {
+	// Error obtains the error message associated with the error.
+	Error() string
+	// Message returns the first level error message without further details.
+	Message() string
+	// DebugMessages returns a detailed string for debug purpose.
+	DebugMessages() string
+	// Kind returns the error kind of this edge error.
+	Kind() ErrKind
+	// Details returns the detailed mapping associated with this edge error.
+	Details() ErrDetails
+}


### PR DESCRIPTION
Add error abstraction and base error implementation to represent internal errors for go-mod-edge-utils.  This errors package is similar to https://github.com/edgexfoundry/go-mod-core-contracts/tree/main/errors with following differences:

1. BaseError contains ErrDetails that can be used to store some error details, e.g. failed certification content, SQL state codes, to expose more error details.
2. Ditch the Code(int), as the original code primarily maps to HTTP status code but the go-mod-edge-utils doesn't necessarily support REST API so the mapping becomes meaningless.  The design idea of this errors package is simply provides a BaseError implementation and we can provide specific new error implementaion, e.g HTTPError, PostgresError based on BaseError per requirement.

  