### PR TITLE
EDX-4406 Refactor go-mod-edge-utils to process configuration with interface rather than pointer

### DIFF
--- a/pkg/bootstrap/bootstrap.go
+++ b/pkg/bootstrap/bootstrap.go
@@ -24,7 +24,6 @@ import (
 	"sync"
 	"syscall"
 
-	"github.com/IOTechSystems/go-mod-edge-utils/pkg/bootstrap/config"
 	"github.com/IOTechSystems/go-mod-edge-utils/pkg/bootstrap/configprocessor"
 	"github.com/IOTechSystems/go-mod-edge-utils/pkg/bootstrap/container"
 	"github.com/IOTechSystems/go-mod-edge-utils/pkg/bootstrap/environment"
@@ -80,7 +79,7 @@ func RunAndReturnWaitGroup(
 	cancel context.CancelFunc,
 	commonFlags flags.Common,
 	serviceKey string,
-	serviceConfig *config.GeneralConfiguration,
+	serviceConfig interfaces.Configuration,
 	startupTimer startup.Timer,
 	dic *di.Container,
 	useSecretProvider bool,
@@ -152,7 +151,7 @@ func Run(
 	cancel context.CancelFunc,
 	commonFlags flags.Common,
 	serviceKey string,
-	serviceConfig *config.GeneralConfiguration,
+	serviceConfig interfaces.Configuration,
 	startupTimer startup.Timer,
 	dic *di.Container,
 	useSecretProvider bool,

--- a/pkg/bootstrap/bootstrap.go
+++ b/pkg/bootstrap/bootstrap.go
@@ -121,7 +121,7 @@ func RunAndReturnWaitGroup(
 	}
 
 	dic.Update(di.ServiceConstructorMap{
-		container.ConfigurationStructName: func(get di.Get) any {
+		container.ConfigurationInterfaceName: func(get di.Get) any {
 			return serviceConfig
 		},
 		container.CancelFuncName: func(get di.Get) any {

--- a/pkg/bootstrap/config/types.go
+++ b/pkg/bootstrap/config/types.go
@@ -30,6 +30,24 @@ type GeneralConfiguration struct {
 	Mqtt5Config     map[string]models.Mqtt5Config
 }
 
+// GetBootstrap returns the configuration elements required by the bootstrap.
+func (c *GeneralConfiguration) GetBootstrap() BootstrapConfiguration {
+	// temporary until we can make backwards-breaking configuration.yaml change
+	return BootstrapConfiguration{
+		Service: &c.Service,
+	}
+}
+
+// GetLogLevel returns the current ConfigurationStruct's log level.
+func (c *GeneralConfiguration) GetLogLevel() string {
+	return c.LogLevel
+}
+
+// GetInsecureSecrets gets the config.InsecureSecrets field from the ConfigurationStruct.
+func (c *GeneralConfiguration) GetInsecureSecrets() InsecureSecrets {
+	return c.InsecureSecrets
+}
+
 // ServiceInfo contains configuration settings necessary for the basic operation of any Edge service.
 type ServiceInfo struct {
 	// Host is the hostname or IP address of the service.

--- a/pkg/bootstrap/config/types.go
+++ b/pkg/bootstrap/config/types.go
@@ -27,12 +27,13 @@ type GeneralConfiguration struct {
 	Service         ServiceInfo
 	SecretStore     SecretStoreInfo
 	InsecureSecrets InsecureSecrets
-	Mqtt5Config     map[string]models.Mqtt5Config
+	Mqtt5Configs    Mqtt5Configs
 }
+
+type Mqtt5Configs map[string]models.Mqtt5Config
 
 // GetBootstrap returns the configuration elements required by the bootstrap.
 func (c *GeneralConfiguration) GetBootstrap() BootstrapConfiguration {
-	// temporary until we can make backwards-breaking configuration.yaml change
 	return BootstrapConfiguration{
 		Service: &c.Service,
 	}
@@ -46,6 +47,11 @@ func (c *GeneralConfiguration) GetLogLevel() string {
 // GetInsecureSecrets gets the config.InsecureSecrets field from the ConfigurationStruct.
 func (c *GeneralConfiguration) GetInsecureSecrets() InsecureSecrets {
 	return c.InsecureSecrets
+}
+
+// GetMqtt5Configs gets the config.Mqtt5Configs from the configuration struct.
+func (c *GeneralConfiguration) GetMqtt5Configs() Mqtt5Configs {
+	return c.Mqtt5Configs
 }
 
 // ServiceInfo contains configuration settings necessary for the basic operation of any Edge service.

--- a/pkg/bootstrap/configprocessor/processor.go
+++ b/pkg/bootstrap/configprocessor/processor.go
@@ -25,7 +25,6 @@ import (
 	"path/filepath"
 	"sync"
 
-	"github.com/IOTechSystems/go-mod-edge-utils/pkg/bootstrap/config"
 	"github.com/IOTechSystems/go-mod-edge-utils/pkg/bootstrap/container"
 	"github.com/IOTechSystems/go-mod-edge-utils/pkg/bootstrap/environment"
 	"github.com/IOTechSystems/go-mod-edge-utils/pkg/bootstrap/flags"
@@ -78,7 +77,7 @@ func NewProcessor(
 
 func (cp *Processor) Process(
 	serviceType string,
-	serviceConfig *config.GeneralConfiguration,
+	serviceConfig interfaces.Configuration,
 	secretProvider interfaces.SecretProviderExt) error {
 
 	if err := cp.loadFromFile(serviceConfig, "service"); err != nil {
@@ -95,7 +94,7 @@ func (cp *Processor) Process(
 	cp.logger.Infof("Configuration loaded from file with %d overrides applied", overrideCount)
 
 	// Now that configuration has been loaded and overrides applied the log level can be set as configured.
-	err = cp.logger.SetLogLevel(serviceConfig.LogLevel)
+	err = cp.logger.SetLogLevel(serviceConfig.GetLogLevel())
 
 	return err
 }

--- a/pkg/bootstrap/container/configuration.go
+++ b/pkg/bootstrap/container/configuration.go
@@ -16,14 +16,19 @@
 package container
 
 import (
-	"github.com/IOTechSystems/go-mod-edge-utils/pkg/bootstrap/config"
+	"github.com/IOTechSystems/go-mod-edge-utils/pkg/bootstrap/interfaces"
 	"github.com/IOTechSystems/go-mod-edge-utils/pkg/di"
 )
 
 // ConfigurationInterfaceName contains the name of the interfaces.Configuration implementation in the DIC.
-var ConfigurationStructName = di.TypeInstanceToName(config.GeneralConfiguration{})
+var ConfigurationInterfaceName = di.TypeInstanceToName((*interfaces.Configuration)(nil))
 
 // ConfigurationFrom helper function queries the DIC and returns the interfaces.Configuration implementation.
-func ConfigurationFrom(get di.Get) *config.GeneralConfiguration {
-	return get(ConfigurationStructName).(*config.GeneralConfiguration)
+func ConfigurationFrom(get di.Get) interfaces.Configuration {
+	configuration, ok := get(ConfigurationInterfaceName).(interfaces.Configuration)
+	if !ok {
+		return nil
+	}
+
+	return configuration
 }

--- a/pkg/bootstrap/container/secret.go
+++ b/pkg/bootstrap/container/secret.go
@@ -36,7 +36,7 @@ func SecretProviderFrom(get di.Get) interfaces.SecretProvider {
 }
 
 // SecretProviderExtName contains the name of the interfaces.SecretProviderExt implementation in the DIC.
-var SecretProviderExtName = di.TypeInstanceToName((*interfaces.SecretProvider)(nil))
+var SecretProviderExtName = di.TypeInstanceToName((*interfaces.SecretProviderExt)(nil))
 
 // SecretProviderExtFrom helper function queries the DIC and returns the interfaces.SecretProviderExt
 // implementation.

--- a/pkg/bootstrap/handlers/message.go
+++ b/pkg/bootstrap/handlers/message.go
@@ -50,7 +50,7 @@ func (h StartMessage) BootstrapHandler(
 	logger.Info("Service dependencies resolved...")
 	logger.Infof("Starting %s %s ", h.serviceKey, h.version)
 
-	startupMsg := container.ConfigurationFrom(dic.Get).Service.StartupMsg
+	startupMsg := container.ConfigurationFrom(dic.Get).GetBootstrap().Service.StartupMsg
 	if len(startupMsg) > 0 {
 		logger.Info(startupMsg)
 	}

--- a/pkg/bootstrap/interfaces/configuration.go
+++ b/pkg/bootstrap/interfaces/configuration.go
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright 2019 Dell Inc.
+ * Copyright 2022 Intel Inc.
+ * Copyright 2023 IOTech Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package interfaces
+
+import "github.com/IOTechSystems/go-mod-edge-utils/pkg/bootstrap/config"
+
+// Configuration interface provides an abstraction around a configuration struct.
+type Configuration interface {
+
+	// GetBootstrap returns the configuration elements required by the bootstrap.
+	GetBootstrap() config.BootstrapConfiguration
+
+	// GetLogLevel returns the current ConfigurationStruct's log level.
+	GetLogLevel() string
+
+	// GetInsecureSecrets gets the config.InsecureSecrets field from the ConfigurationStruct.
+	GetInsecureSecrets() config.InsecureSecrets
+}

--- a/pkg/bootstrap/interfaces/configuration.go
+++ b/pkg/bootstrap/interfaces/configuration.go
@@ -27,6 +27,9 @@ type Configuration interface {
 	// GetLogLevel returns the current ConfigurationStruct's log level.
 	GetLogLevel() string
 
-	// GetInsecureSecrets gets the config.InsecureSecrets field from the ConfigurationStruct.
+	// GetInsecureSecrets gets the config.InsecureSecrets field from the configuration struct.
 	GetInsecureSecrets() config.InsecureSecrets
+
+	// GetMqtt5Configs gets the config.Mqtt5Configs from the configuration struct.
+	GetMqtt5Configs() config.Mqtt5Configs
 }

--- a/pkg/bootstrap/secret/insecure.go
+++ b/pkg/bootstrap/secret/insecure.go
@@ -18,12 +18,12 @@ package secret
 import (
 	"errors"
 	"fmt"
+	"github.com/IOTechSystems/go-mod-edge-utils/pkg/bootstrap/interfaces"
 	"strings"
 	"time"
 
 	gometrics "github.com/rcrowley/go-metrics"
 
-	"github.com/IOTechSystems/go-mod-edge-utils/pkg/bootstrap/config"
 	"github.com/IOTechSystems/go-mod-edge-utils/pkg/di"
 	"github.com/IOTechSystems/go-mod-edge-utils/pkg/log"
 )
@@ -31,7 +31,7 @@ import (
 // InsecureProvider implements the SecretProvider interface for insecure secrets
 type InsecureProvider struct {
 	logger                    log.Logger
-	configuration             *config.InsecureSecrets
+	configuration             interfaces.Configuration
 	lastUpdated               time.Time
 	registeredSecretCallbacks map[string]func(secretName string)
 	securitySecretsRequested  gometrics.Counter
@@ -40,9 +40,9 @@ type InsecureProvider struct {
 }
 
 // NewInsecureProvider creates, initializes Provider for insecure secrets.
-func NewInsecureProvider(config *config.GeneralConfiguration, logger log.Logger, dic *di.Container) *InsecureProvider {
+func NewInsecureProvider(config interfaces.Configuration, logger log.Logger, dic *di.Container) *InsecureProvider {
 	return &InsecureProvider{
-		configuration:             &config.InsecureSecrets,
+		configuration:             config,
 		logger:                    logger,
 		lastUpdated:               time.Now(),
 		registeredSecretCallbacks: make(map[string]func(secretName string)),
@@ -63,7 +63,7 @@ func (p *InsecureProvider) GetSecret(secretName string, keys ...string) (map[str
 	secretNameExists := false
 	var missingKeys []string
 
-	insecureSecrets := *p.configuration
+	insecureSecrets := p.configuration.GetInsecureSecrets()
 	if insecureSecrets == nil {
 		err := fmt.Errorf("InsecureSecrets missing from configuration")
 		return nil, err
@@ -128,7 +128,7 @@ func (p *InsecureProvider) GetAccessToken(_ string, _ string) (string, error) {
 
 // HasSecret returns true if the service's SecretStore contains a secret at the specified secretName.
 func (p *InsecureProvider) HasSecret(secretName string) (bool, error) {
-	insecureSecrets := *p.configuration
+	insecureSecrets := p.configuration.GetInsecureSecrets()
 	if insecureSecrets == nil {
 		err := fmt.Errorf("InsecureSecret missing from configuration")
 		return false, err
@@ -147,7 +147,7 @@ func (p *InsecureProvider) HasSecret(secretName string) (bool, error) {
 func (p *InsecureProvider) ListSecretNames() ([]string, error) {
 	var results []string
 
-	insecureSecrets := *p.configuration
+	insecureSecrets := p.configuration.GetInsecureSecrets()
 	if insecureSecrets == nil {
 		err := fmt.Errorf("InsecureSecrets missing from configuration")
 		return nil, err

--- a/pkg/bootstrap/secret/secret.go
+++ b/pkg/bootstrap/secret/secret.go
@@ -19,7 +19,6 @@ package secret
 import (
 	"context"
 
-	"github.com/IOTechSystems/go-mod-edge-utils/pkg/bootstrap/config"
 	"github.com/IOTechSystems/go-mod-edge-utils/pkg/bootstrap/container"
 	"github.com/IOTechSystems/go-mod-edge-utils/pkg/bootstrap/environment"
 	"github.com/IOTechSystems/go-mod-edge-utils/pkg/bootstrap/interfaces"
@@ -35,7 +34,7 @@ const (
 
 // NewSecretProvider creates a new fully initialized the Secret Provider.
 func NewSecretProvider(
-	configuration *config.GeneralConfiguration,
+	configuration interfaces.Configuration,
 	envVars *environment.Variables,
 	ctx context.Context,
 	startupTimer startup.Timer,

--- a/pkg/mqtt5/bootstrap/handler.go
+++ b/pkg/mqtt5/bootstrap/handler.go
@@ -23,7 +23,7 @@ func Mqtt5BootstrapHandler(ctx context.Context, wg *sync.WaitGroup, startupTimer
 	if secretProvider == nil {
 		logger.Error("Secret provider is missing. Make sure it is specified to be used in bootstrap.Run()")
 	}
-	mqtt5ConfigMap := container.ConfigurationFrom(dic.Get).Mqtt5Config
+	mqtt5ConfigMap := container.ConfigurationFrom(dic.Get).GetMqtt5Configs()
 	if mqtt5ConfigMap == nil {
 		logger.Error("No Mqtt5Config configuration provided")
 		return false


### PR DESCRIPTION
The current go-mod-edge-utils process configuration as pointer: (https://github.com/IOTechSystems/go-mod-edge-utils/blob/v1.0.2/pkg/bootstrap/configprocessor/processor.go#L81) This way will restrict the configuration must be the struct as defined in https://github.com/IOTechSystems/go-mod-edge-utils/blob/v1.0.2/pkg/bootstrap/config/types.go#L27-L33, which is not flexible to services that require extra configuration.

We should change the configprocessor to process configuration as interface, just like what https://github.com/edgexfoundry/go-mod-bootstrap/blob/v3.1.0/bootstrap/config/config.go#L125 implemented, so other services that use go-mod-edge-utils can still define their own configuration based on the go-mod-edge-utils.