### PR TITLE
EDX-7047 Correct the usage of strings.HasPrefix

### DIFF
--- a/pkg/bootstrap/handlers/tls/seed/x590.go
+++ b/pkg/bootstrap/handlers/tls/seed/x590.go
@@ -46,7 +46,7 @@ func NewX509(configFilePtr string) (X509, error) {
 	}
 
 	tlsHost := jsonX509Config.TLSServer.TLSHost
-	if strings.HasPrefix(envPrefix, tlsHost) {
+	if strings.HasPrefix(tlsHost, envPrefix) {
 		host := os.Getenv(strings.TrimPrefix(tlsHost, envPrefix))
 		if host == "" {
 			host = hostDefault


### PR DESCRIPTION
The original code incorrectly specifies the prefix as the first parameter, resulting in the bug where environment variable substitution never occurs.

Fix this behavior by swapping the parameters for strings.HasPrefix.