### PR TITLE
EDX-6943 Add publisher-driven SSE progress tracker

### DIFF
--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -2,12 +2,20 @@
 
 package common
 
+// constants relate to the HTTP header
 const (
-	CorrelationID   = "X-Correlation-ID"
-	ContentType     = "Content-Type"
-	ContentTypeJSON = "application/json"
-	ContentTypeYAML = "application/yaml"
-	ContentTypeText = "text/plain"
+	CorrelationID          = "X-Correlation-ID"
+	ContentType            = "Content-Type"
+	ContentTypeJSON        = "application/json"
+	ContentTypeYAML        = "application/yaml"
+	ContentTypeText        = "text/plain"
+	ContentTypeEventStream = "text/event-stream"
+
+	CacheControl = "Cache-Control"
+	NoCache      = "no-cache"
+
+	Connection = "Connection"
+	KeepAlive  = "keep-alive"
 )
 
 const (

--- a/pkg/sse/handler.go
+++ b/pkg/sse/handler.go
@@ -60,12 +60,15 @@ func ConstructSSETopic(c echo.Context) string {
 }
 
 func handleSSE(c echo.Context, serviceCtx context.Context, b *broadcaster, ch subscriberCh, heartbeatInterval time.Duration) error {
-	WriteSSEHeaders(c, b.lc)
-
 	if heartbeatInterval <= 0 {
 		b.lc.Debug("sse: heartbeat interval is not set or invalid, using default value: 30s")
 		heartbeatInterval = defaultHeartbeatInterval
 	}
+
+	if err := WriteSSEHeaders(c, heartbeatInterval, b.lc); err != nil {
+		return err
+	}
+
 	heartbeatTicker := time.NewTicker(heartbeatInterval)
 	defer heartbeatTicker.Stop()
 

--- a/pkg/sse/handler.go
+++ b/pkg/sse/handler.go
@@ -6,9 +6,6 @@ package sse
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
-	"net/http"
 	"time"
 
 	"github.com/labstack/echo/v4"
@@ -63,16 +60,7 @@ func ConstructSSETopic(c echo.Context) string {
 }
 
 func handleSSE(c echo.Context, serviceCtx context.Context, b *broadcaster, ch subscriberCh, heartbeatInterval time.Duration) error {
-	// Flush the SSE response headers immediately so clients waiting for the
-	// "text/event-stream" content type can start processing the stream.
-	setSSEHeaders(c)
-	if f, ok := c.Response().Writer.(http.Flusher); ok {
-		f.Flush()
-	} else {
-		// Normal Echo deployments support flushing; this branch is mainly for
-		// tests or custom middleware that wrap the ResponseWriter.
-		b.lc.Warn("sse: ResponseWriter does not support flushing, SSE may not work as expected")
-	}
+	WriteSSEHeaders(c, b.lc)
 
 	if heartbeatInterval <= 0 {
 		b.lc.Debug("sse: heartbeat interval is not set or invalid, using default value: 30s")
@@ -80,11 +68,6 @@ func handleSSE(c echo.Context, serviceCtx context.Context, b *broadcaster, ch su
 	}
 	heartbeatTicker := time.NewTicker(heartbeatInterval)
 	defer heartbeatTicker.Stop()
-
-	// ResponseController lets us apply per-write deadlines on the underlying
-	// network connection so a slow or broken client surfaces as a write
-	// error instead of an indefinite block.
-	rc := http.NewResponseController(c.Response().Writer)
 
 	for {
 		select {
@@ -94,36 +77,16 @@ func handleSSE(c echo.Context, serviceCtx context.Context, b *broadcaster, ch su
 				b.lc.Debug("sse: subscriber channel closed")
 				return nil
 			}
-			msgJSON, err := json.Marshal(msg)
-			if err != nil {
-				b.lc.Errorf("sse: failed to serialize message: %v", err)
-				continue
-			}
-
-			if err := rc.SetWriteDeadline(time.Now().Add(heartbeatInterval)); err != nil {
-				b.lc.Errorf("sse: failed to set write deadline or not supported: %v", err)
-				return nil
-			}
-
-			if _, err = fmt.Fprintf(c.Response().Writer, "data: %s\n\n", msgJSON); err != nil {
+			if err := WriteSSEEvent(c, msg, heartbeatInterval, b.lc); err != nil {
 				b.lc.Errorf("sse: failed to write message: %v", err)
 				return nil
 			}
 
-			c.Response().Flush()
-
 		case <-heartbeatTicker.C:
-			if err := rc.SetWriteDeadline(time.Now().Add(heartbeatInterval)); err != nil {
-				b.lc.Errorf("sse: failed to set write deadline or not supported for heartbeat: %v", err)
-				return nil
-			}
-
-			if _, err := fmt.Fprintf(c.Response().Writer, ":\n\n"); err != nil {
+			if err := WriteHeartbeat(c, heartbeatInterval, b.lc); err != nil {
 				b.lc.Warnf("sse: heartbeat write failed: %v", err)
 				return nil
 			}
-
-			c.Response().Flush()
 
 		case <-c.Request().Context().Done():
 			b.lc.Debug("sse: request cancelled or timed out")
@@ -134,10 +97,4 @@ func handleSSE(c echo.Context, serviceCtx context.Context, b *broadcaster, ch su
 			return nil
 		}
 	}
-}
-
-func setSSEHeaders(c echo.Context) {
-	c.Response().Header().Set(echo.HeaderContentType, "text/event-stream")
-	c.Response().Header().Set("Cache-Control", "no-cache")
-	c.Response().Header().Set("Connection", "keep-alive")
 }

--- a/pkg/sse/progress/README.md
+++ b/pkg/sse/progress/README.md
@@ -129,14 +129,14 @@ This package (and the parent `pkg/sse`) **requires** the `ResponseWriter` chain 
 
 Stock Echo + `net/http` meets this out of the box. Custom middleware that wraps the writer MUST forward `Unwrap()`. If the requirement is not met:
 
-- `WriteSSEHeaders` logs `Errorf` once at stream start naming the missing capability
-- The first event or heartbeat write returns an error and the handler exits cleanly (200 OK, no data)
+- `WriteSSEHeaders` returns an error before flushing any bytes, so `Subscribe` exits with a proper 5xx instead of committing 200 and dying on the first event
+- The diagnostic `Errorf` log names the failed `SetWriteDeadline` capability so ops can locate the offending middleware
 
 Fail-loud is intentional. Tolerating a missing deadline silently disables slow-client protection — a slow reader could otherwise keep a server-side goroutine blocked in `fmt.Fprintf` indefinitely, since no in-Go mechanism can cancel that write without `SetWriteDeadline`.
 
 Tests use a fixture that implements `SetWriteDeadline` as a no-op (see `flushableRecorder` in `subscribe_test.go`).
 
-> **Note**: no current deployment of this package uses middleware that breaks `ResponseController` — every active call site sits on stock Echo. This section is recorded as a forward reference: if some future integration ever returns 200-then-immediately-close on its first SSE request, the probe log here is the first thing to check, and the path forward is either to fix the offending middleware to forward `Unwrap()` or to introduce an explicit fallback (e.g. `goroutine + select` timeout) in `pkg/sse/utils.go`.
+> **Note**: no current deployment of this package uses middleware that breaks `ResponseController` — every active call site sits on stock Echo. This section is recorded as a forward reference: if some future integration ever returns 5xx on its first SSE request, the diagnostic log here is the first thing to check, and the path forward is either to fix the offending middleware to forward `Unwrap()` or to introduce an explicit fallback (e.g. `goroutine + select` timeout) in `pkg/sse/utils.go`.
 
 ## What this package does NOT do
 

--- a/pkg/sse/progress/README.md
+++ b/pkg/sse/progress/README.md
@@ -1,0 +1,150 @@
+# sse/progress — Publisher-driven async-progress SSE
+
+`progress.Tracker` is the publisher-driven sibling of [`pkg/sse`](../). Use it when an HTTP-triggered async operation has a definite terminal (success or failure) and the client wants to observe progress over an SSE stream that opens slightly before, during, or shortly after the job runs.
+
+## Scope — when to use this package
+
+This package is designed for **bounded async operations with a terminal**, emitting **monotonic snapshot events**:
+
+- A trigger starts the work (typically an HTTP POST).
+- Work emits a sequence of progress events ending in `Job.Finish`.
+- Each event is a snapshot — later events subsume earlier ones (e.g. `progress=70%` carries everything `progress=30%` did; `result={count: 10, items: [...]}` carries everything `result={count: 5, ...}` did).
+- Subscribers observe events from any point in time; late subscribers see the **latest cached event** then live tail.
+
+Memory cost is O(1) per Job — only the most recent payload is held. Retention drops the Job after the terminal window expires.
+
+**Cache-last vs full-log replay.** Earlier revisions retained the full event log so late subscribers saw the complete history. The current design caches only the last event because the in-use cases (discovery progress, auto-tagging results) emit cumulative snapshots where intermediate events are redundant. Caching one event eliminates the replay-window event-drop race and bounds memory cost. **Delta-style events** — e.g. emitting `"found device A"` and `"found device B"` as separate events that don't include the cumulative list — are not supported; encode such state into a snapshot payload instead, or use `pkg/sse.Manager` with caller-side history.
+
+**Do NOT use this package for:**
+
+| Scenario | Use instead |
+| --- | --- |
+| High-volume event streams (MQTT bus relay, telemetry) | `pkg/sse.Manager` |
+| Subscriber-driven polling without a terminal (lists, dashboards, logs) | `pkg/sse.NewPolling` |
+| Delta-style events where every payload carries unique information | rethink — either coalesce into snapshots, or use `pkg/sse.Manager` with caller-side history |
+
+## Quick start
+
+```go
+import (
+    "github.com/IOTechSystems/go-mod-edge-utils/v2/pkg/sse/progress"
+)
+
+// At service startup, one Tracker per progress-style flow.
+tracker := progress.New(serviceCtx, 30*time.Second, 30*time.Second, lc)
+
+// On the POST that triggers the work:
+job, isNew := tracker.Start("discovery/" + edgeInst + "/" + service)
+if !isNew {
+    // Coalesce: another trigger is already running on this topic; the
+    // caller typically returns 200 to signal "joined existing".
+    return ok200(c)
+}
+
+go func() {
+    // Safety-net terminal in case work returns early without calling
+    // Finish (idempotent — the happy-path Finish below wins if called).
+    defer job.Finish(progressFailed(errors.New("job did not complete")))
+
+    if err := doWork(ctx, job); err != nil {
+        job.Finish(progressFailed(err))
+        return
+    }
+    job.Finish(progressDone())
+}()
+return accepted202(c)
+
+// On the GET that streams progress:
+func (c controller) listen(ec echo.Context) error {
+    err := tracker.Subscribe(ec, topic)
+    if errors.Is(err, progress.ErrNoTopic) {
+        return ec.JSON(http.StatusNotFound, ...)
+    }
+    return err
+}
+
+// doWork emits progress directly on the Job — no callback indirection.
+func doWork(ctx context.Context, job *progress.Job) error {
+    job.Publish(progressStarted())
+    // ... work ...
+    return nil
+}
+```
+
+## Two entry points: Start vs StartOrJoin
+
+Both atomically return `(*Job, isNew bool)`. The difference is what happens when the topic has a **retained terminal** entry:
+
+| Entry point | Running entry | Retained terminal entry | No entry |
+| --- | --- | --- | --- |
+| `Start` | Join (isNew=false) | **Discard and create fresh** (isNew=true) | Create (isNew=true) |
+| `StartOrJoin` | Join (isNew=false) | **Reuse retained** (isNew=false) | Create (isNew=true) |
+
+Selection rule:
+
+- **Trigger-driven flows** (user clicks "Start scan", HTTP POST) → `Start`. Each trigger conceptually starts a new run; the retained terminal from a previous run must not be observed as if it were the new run's result.
+- **Subscribe-driven flows** ("compute the tag-scan result once; many dashboards subscribe to it") → `StartOrJoin`. Late subscribers should see the cached terminal, not retrigger the work.
+
+Both methods are atomic over `Tracker.mu`; concurrent callers on the same topic see exactly one `isNew=true` and the rest coalesce.
+
+## Lifecycle
+
+```
+        (no entry)
+             |
+             | Start / StartOrJoin (isNew=true)
+             v
+        +---------+
+        | Running |  -- Publish (updates last + fans out latest-wins)
+        +---------+
+             |
+             | Finish (terminal, idempotent)
+             v
+        +----------+
+        | Retained |  -- late subscribers within retention see the
+        +----------+     cached terminal and close.
+             |
+             | cleanup (retention expires OR tracker ctx cancelled)
+             v
+        (no entry)
+```
+
+`Start` on a retained entry creates a fresh Job, replacing the map entry. The previous Job's cleanup goroutine sees the identity check fail (`jobs[topic] != prevJob`) and leaves the new entry alone.
+
+## API
+
+| Symbol | Role |
+| --- | --- |
+| `New(ctx, retention, heartbeat, lc)` | Construct a Tracker; zero/negative durations use 30s defaults. |
+| `Tracker.Start(topic)` | Trigger-driven entry. Returns `(*Job, isNew bool)`. |
+| `Tracker.StartOrJoin(topic)` | Subscriber-driven entry. Reuses retained. Returns `(*Job, isNew bool)`. |
+| `Tracker.Subscribe(c, topic)` | Attach an SSE subscriber. Writes the cached last event then live tail. Returns `ErrNoTopic` if topic is unknown. |
+| `Job.Publish(data)` | Update cached last + fan out (latest-wins). No-op once terminal. |
+| `Job.Finish(data)` | Cache terminal + close subscribers + start retention. Idempotent. |
+| `ErrNoTopic` | Sentinel: no active or recent Job for topic. |
+
+## Runtime requirement
+
+This package (and the parent `pkg/sse`) **requires** the `ResponseWriter` chain to expose `SetWriteDeadline` via `http.ResponseController` — directly or through `Unwrap()`. It is the only standard way Go offers to bound a stuck `Write` on a slow/dead client.
+
+Stock Echo + `net/http` meets this out of the box. Custom middleware that wraps the writer MUST forward `Unwrap()`. If the requirement is not met:
+
+- `WriteSSEHeaders` logs `Errorf` once at stream start naming the missing capability
+- The first event or heartbeat write returns an error and the handler exits cleanly (200 OK, no data)
+
+Fail-loud is intentional. Tolerating a missing deadline silently disables slow-client protection — a slow reader could otherwise keep a server-side goroutine blocked in `fmt.Fprintf` indefinitely, since no in-Go mechanism can cancel that write without `SetWriteDeadline`.
+
+Tests use a fixture that implements `SetWriteDeadline` as a no-op (see `flushableRecorder` in `subscribe_test.go`).
+
+> **Note**: no current deployment of this package uses middleware that breaks `ResponseController` — every active call site sits on stock Echo. This section is recorded as a forward reference: if some future integration ever returns 200-then-immediately-close on its first SSE request, the probe log here is the first thing to check, and the path forward is either to fix the offending middleware to forward `Unwrap()` or to introduce an explicit fallback (e.g. `goroutine + select` timeout) in `pkg/sse/utils.go`.
+
+## What this package does NOT do
+
+- **Mutual exclusion across calls** — `Start` coalesces concurrent same-topic triggers, but cross-topic mutual exclusion (e.g. profile scan blocking discovery on the same edge instance) belongs in the caller. Use a per-resource lock alongside the tracker.
+- **De-duplication of payloads** — emit at whatever cadence your work loop generates. A subscriber may briefly observe the cached event echoed on the wire if a same-value `Publish` lands between attach and the live loop's first iteration; harmless for idempotent progress payloads.
+- **Full event history replay** — late subscribers receive only the latest cached event. Design events as monotonic snapshots (see "Scope" above). The previous full-log design was reverted because its replay window introduced an event-drop race with no benefit for snapshot-style payloads.
+
+## See also
+
+- Parent package: [`../`](../) — `Manager` / `broadcaster` / `PollingService`.
+- The internal lock model is `Tracker.mu` → `Job.mu`, never reversed. `Publish` / `Finish` touch only `Job.mu`; `Start` / `StartOrJoin` / cleanup touch only `Tracker.mu` for the brief map mutation (with `isTerminal()` on a retained entry the only Job.mu acquisition under Tracker.mu, matching the lock order). Cleanup goroutines wake on `j.finished` or `tracker.ctx.Done()`; deletion is gated by an identity check so a replacement Job survives an orphaned old Job's cleanup pass.

--- a/pkg/sse/progress/concurrency_test.go
+++ b/pkg/sse/progress/concurrency_test.go
@@ -1,0 +1,170 @@
+//
+// Copyright (C) 2026 IOTech Ltd
+//
+
+package progress
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestConcurrency_StartOrJoinPublishSubscribe stresses the hot paths
+// under -race: many goroutines on shared topics, all expected to drain
+// without races, deadlocks, or stale-map entries.
+func TestConcurrency_StartOrJoinPublishSubscribe(t *testing.T) {
+	tr := New(context.Background(), 50*time.Millisecond, time.Second, newTestLogger(t))
+
+	const (
+		topics     = 8
+		publishers = 4
+		each       = 200
+	)
+	var wg sync.WaitGroup
+	for i := 0; i < topics; i++ {
+		topic := topicName(i)
+		for p := 0; p < publishers; p++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				j, _ := tr.StartOrJoin(topic)
+				for k := 0; k < each; k++ {
+					j.Publish(k)
+				}
+				j.Finish("done")
+			}()
+		}
+	}
+	wg.Wait()
+
+	require.Eventually(t, func() bool {
+		tr.mu.RLock()
+		empty := len(tr.jobs) == 0
+		tr.mu.RUnlock()
+		return empty
+	}, 5*time.Second, 10*time.Millisecond)
+}
+
+// TestConcurrency_StartReplaceRetainedDuringPublish — Start replaces a
+// retained Job with a fresh one; concurrent (no-op) Publish on the
+// orphaned Job + (live) Publish on the replacement must not race, and
+// the old Job's cleanup must not evict the replacement.
+func TestConcurrency_StartReplaceRetainedDuringPublish(t *testing.T) {
+	tr := New(context.Background(), 30*time.Millisecond, time.Second, newTestLogger(t))
+
+	old, _ := tr.Start("topic-orphan")
+	old.Finish("orphan terminal")
+
+	replacement, isNew := tr.Start("topic-orphan")
+	require.True(t, isNew)
+	assert.NotSame(t, old, replacement)
+
+	// Publish on both; the old (terminal) is a no-op.
+	var publishCount atomic.Int64
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				old.Publish(publishCount.Add(1))
+			}
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				replacement.Publish(publishCount.Add(1))
+			}
+		}
+	}()
+
+	time.Sleep(80 * time.Millisecond) // > retention; let old's cleanup fire
+	close(stop)
+	wg.Wait()
+
+	tr.mu.RLock()
+	stored, ok := tr.jobs["topic-orphan"]
+	tr.mu.RUnlock()
+	require.True(t, ok)
+	assert.Same(t, replacement, stored)
+
+	replacement.Finish("replacement terminal")
+	require.Eventually(t, func() bool {
+		tr.mu.RLock()
+		_, ok := tr.jobs["topic-orphan"]
+		tr.mu.RUnlock()
+		return !ok
+	}, time.Second, 5*time.Millisecond)
+}
+
+// TestConcurrency_SubscribeHoldsLockThroughAttach — regression: Subscribe
+// must hold Tracker.mu (read) across both lookup AND j.mu acquisition
+// inside attach. Otherwise a concurrent Start replacing a retained
+// entry would slip into the gap and the subscriber would attach to the
+// stale Job.
+func TestConcurrency_SubscribeHoldsLockThroughAttach(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	tr := New(ctx, 10*time.Second, time.Second, newTestLogger(t))
+
+	jobA, _ := tr.Start("topic")
+	jobA.Finish("a") // retained → Subscribe returns immediately after attach
+
+	startAttempted := make(chan struct{})
+	startReturned := make(chan struct{})
+	var observedDuringHook *Job
+
+	tr.attachHookForTest = func() {
+		// Drive a concurrent Start while Subscribe is between lookup
+		// and attach. With the lock held, this Start (needs
+		// Tracker.mu.Lock to replace the retained entry) must block.
+		go func() {
+			close(startAttempted)
+			tr.Start("topic")
+			close(startReturned)
+		}()
+		<-startAttempted
+
+		select {
+		case <-startReturned:
+			t.Errorf("Start replacement landed while Subscribe held the read lock")
+		case <-time.After(50 * time.Millisecond):
+			// Expected: blocked.
+		}
+
+		observedDuringHook = tr.jobs["topic"]
+	}
+
+	_, c, cancelReq := newSubscribeFixture(t)
+	defer cancelReq()
+	require.NoError(t, tr.Subscribe(c, "topic"))
+
+	<-startReturned // Subscribe released the read lock; replacement lands
+
+	assert.Same(t, jobA, observedDuringHook,
+		"hook must observe original Job under Subscribe's read lock")
+
+	tr.mu.RLock()
+	stored := tr.jobs["topic"]
+	tr.mu.RUnlock()
+	assert.NotSame(t, jobA, stored)
+}
+
+func topicName(i int) string {
+	return "topic-" + string(rune('a'+i))
+}

--- a/pkg/sse/progress/job.go
+++ b/pkg/sse/progress/job.go
@@ -1,0 +1,104 @@
+//
+// Copyright (C) 2026 IOTech Ltd
+//
+
+package progress
+
+import "sync"
+
+// Job is the publisher handle for one topic-bound async operation. Owned
+// by the goroutine that observed isNew=true from Start / StartOrJoin;
+// subscribers reach it only via Tracker.Subscribe.
+type Job struct {
+	mu sync.Mutex
+
+	done bool
+
+	// last is the most recent payload (progress event or terminal). Late
+	// subscribers replay only this single value, so callers must design
+	// events as monotonic snapshots — see package README "Scope".
+	last    any
+	hasLast bool
+
+	// subscribers receive fan-out via Publish. Each channel is size-1
+	// with latest-wins semantics (Publish drains any pending stale
+	// payload before pushing the new one). Finish closes (does not send
+	// to) the channels; the terminal payload lives in j.last.
+	subscribers map[chan any]struct{}
+
+	// finished is closed by Finish; the cleanup goroutine watches it.
+	finished chan struct{}
+}
+
+func newJob() *Job {
+	return &Job{
+		subscribers: make(map[chan any]struct{}),
+		finished:    make(chan struct{}),
+	}
+}
+
+// Publish updates the cached last payload and fans it out to subscribers
+// with latest-wins semantics. A no-op once terminal. A slow subscriber
+// that has not drained its previous payload sees that payload replaced
+// by this newer one — for monotonic snapshot events, the most recent
+// state is the only state that matters.
+func (j *Job) Publish(data any) {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+
+	if j.done {
+		return
+	}
+
+	j.last = data
+	j.hasLast = true
+
+	for ch := range j.subscribers {
+		// Latest-wins: drain any pending stale payload, then push fresh.
+		// j.mu is held throughout, so the drain+push pair is atomic
+		// relative to other Publishes on this Job.
+		select {
+		case <-ch:
+		default:
+		}
+		select {
+		case ch <- data:
+		default:
+		}
+	}
+}
+
+// Finish marks the job done, caches the terminal in j.last, and closes
+// subscribers (signal only — they read the terminal from j.last under
+// j.mu). Idempotent: defer job.Finish(failed) as a safety-net coexists
+// with an explicit happy-path Finish.
+//
+// Success vs failure is encoded in the payload, not in two methods.
+func (j *Job) Finish(data any) {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+
+	if j.done {
+		return
+	}
+
+	j.done = true
+	j.last = data
+	j.hasLast = true
+
+	for ch := range j.subscribers {
+		close(ch)
+		delete(j.subscribers, ch)
+	}
+
+	close(j.finished)
+}
+
+// isTerminal acquires j.mu — callers must not already hold it. Used by
+// Tracker.Start while holding Tracker.mu; the lock order Tracker.mu →
+// Job.mu makes this safe.
+func (j *Job) isTerminal() bool {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	return j.done
+}

--- a/pkg/sse/progress/job_test.go
+++ b/pkg/sse/progress/job_test.go
@@ -1,0 +1,237 @@
+//
+// Copyright (C) 2026 IOTech Ltd
+//
+
+package progress
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func newTestJob(_ *testing.T) *Job {
+	return newJob()
+}
+
+func TestJob_Publish_UpdatesLastCache(t *testing.T) {
+	j := newTestJob(t)
+
+	j.Publish("e1")
+	j.Publish("e2")
+	j.Publish("e3")
+
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	assert.True(t, j.hasLast)
+	assert.Equal(t, "e3", j.last)
+	assert.False(t, j.done)
+}
+
+func TestJob_Publish_BroadcastsToSubscribers(t *testing.T) {
+	j := newTestJob(t)
+
+	ch1 := make(chan any, subscriberChanBuffer)
+	ch2 := make(chan any, subscriberChanBuffer)
+	j.mu.Lock()
+	j.subscribers[ch1] = struct{}{}
+	j.subscribers[ch2] = struct{}{}
+	j.mu.Unlock()
+
+	j.Publish("event-a")
+
+	for i, ch := range []chan any{ch1, ch2} {
+		select {
+		case got := <-ch:
+			assert.Equal(t, "event-a", got, "subscriber %d", i)
+		case <-time.After(time.Second):
+			t.Fatalf("subscriber %d did not receive event", i)
+		}
+	}
+}
+
+func TestJob_Publish_LatestWinsOnSlowSubscriber(t *testing.T) {
+	// Load-bearing: when the subscriber has not drained its previous
+	// payload, the next Publish replaces it (not queues, not drops the
+	// new one). Channel buffer of 1 + drain-then-push guarantees the
+	// most recent payload is always the one waiting.
+	j := newTestJob(t)
+	ch := make(chan any, subscriberChanBuffer)
+	j.mu.Lock()
+	j.subscribers[ch] = struct{}{}
+	j.mu.Unlock()
+
+	j.Publish("stale")
+	j.Publish("fresh")
+
+	select {
+	case got := <-ch:
+		assert.Equal(t, "fresh", got, "expected latest-wins to replace stale payload")
+	case <-time.After(time.Second):
+		t.Fatal("subscriber did not receive any payload")
+	}
+
+	// Channel must now be empty — only one (latest) value remained.
+	select {
+	case got := <-ch:
+		t.Fatalf("expected empty channel, got %v", got)
+	default:
+	}
+}
+
+func TestJob_Publish_NilPayloadIsValid(t *testing.T) {
+	j := newTestJob(t)
+
+	j.Publish(nil)
+
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	assert.True(t, j.hasLast)
+	assert.Nil(t, j.last)
+}
+
+func TestJob_Publish_ConcurrentPublishers_NoRace(t *testing.T) {
+	// Race-detector smoke test. Correctness of latest-wins coalescing is
+	// covered by TestJob_Publish_LatestWinsOnSlowSubscriber; here we only
+	// assert no race and that hasLast ends true.
+	j := newTestJob(t)
+	ch := make(chan any, subscriberChanBuffer)
+	j.mu.Lock()
+	j.subscribers[ch] = struct{}{}
+	j.mu.Unlock()
+
+	// Drain in the background so Publish never blocks structurally
+	// (it shouldn't anyway — drain-then-push is non-blocking — but a
+	// reader keeps the channel from staying saturated).
+	doneDrain := make(chan struct{})
+	go func() {
+		defer close(doneDrain)
+		for {
+			select {
+			case <-ch:
+			case <-time.After(50 * time.Millisecond):
+				return
+			}
+		}
+	}()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 16; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			for k := 0; k < 32; k++ {
+				j.Publish(i*32 + k)
+			}
+		}(i)
+	}
+	wg.Wait()
+	<-doneDrain
+
+	j.mu.Lock()
+	assert.True(t, j.hasLast)
+	// Some publish must have landed; nil would mean Publish silently
+	// dropped every payload (e.g. the drain-then-push pair regressed).
+	assert.NotNil(t, j.last)
+	j.mu.Unlock()
+}
+
+// ---------- Finish ----------
+
+func TestJob_Finish_CachesTerminalAndClosesSubscribers(t *testing.T) {
+	j := newTestJob(t)
+	ch := make(chan any, subscriberChanBuffer)
+	j.mu.Lock()
+	j.subscribers[ch] = struct{}{}
+	j.mu.Unlock()
+
+	j.Publish("mid")
+	j.Finish("ok")
+
+	// Drain any buffered mid event, then expect a closed channel — the
+	// terminal arrives via j.last, not the channel.
+	for {
+		select {
+		case got, open := <-ch:
+			if !open {
+				goto closed
+			}
+			assert.Equal(t, "mid", got)
+		case <-time.After(time.Second):
+			t.Fatal("subscriber channel was not closed after Finish")
+		}
+	}
+closed:
+
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	assert.True(t, j.done)
+	assert.True(t, j.hasLast)
+	assert.Equal(t, "ok", j.last)
+	assert.Empty(t, j.subscribers)
+
+	select {
+	case <-j.finished:
+	default:
+		t.Fatal("finished channel was not closed after Finish")
+	}
+}
+
+func TestJob_Finish_Idempotent(t *testing.T) {
+	j := newTestJob(t)
+	j.Finish("first")
+	j.Finish("second") // ignored
+
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	assert.True(t, j.done)
+	assert.True(t, j.hasLast)
+	assert.Equal(t, "first", j.last)
+}
+
+func TestJob_Publish_AfterFinishIsNoOp(t *testing.T) {
+	j := newTestJob(t)
+	j.Finish("terminal")
+	j.Publish("late") // ignored
+
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	assert.True(t, j.hasLast)
+	assert.Equal(t, "terminal", j.last)
+}
+
+func TestJob_TerminalSurvivesWithoutChannelRead(t *testing.T) {
+	// Regression: the terminal is stored in j.last, not sent via the
+	// fan-out channel, so it survives even when no subscriber drains the
+	// channel buffer first.
+	j := newTestJob(t)
+	ch := make(chan any, subscriberChanBuffer)
+	j.mu.Lock()
+	j.subscribers[ch] = struct{}{}
+	j.mu.Unlock()
+
+	j.Publish("progress")
+	j.Finish("terminal")
+
+	// Without draining the buffered progress event, observe that:
+	//  - the channel eventually closes (Finish's signal)
+	//  - j.last carries the terminal
+	for {
+		select {
+		case _, open := <-ch:
+			if !open {
+				goto done
+			}
+		case <-time.After(time.Second):
+			t.Fatal("channel was not closed after Finish")
+		}
+	}
+done:
+
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	assert.True(t, j.done)
+	assert.Equal(t, "terminal", j.last)
+}

--- a/pkg/sse/progress/subscribe.go
+++ b/pkg/sse/progress/subscribe.go
@@ -1,0 +1,138 @@
+//
+// Copyright (C) 2026 IOTech Ltd
+//
+
+package progress
+
+import (
+	"errors"
+	"time"
+
+	"github.com/labstack/echo/v4"
+
+	"github.com/IOTechSystems/go-mod-edge-utils/v2/pkg/sse"
+)
+
+// ErrNoTopic — no active or recently-retained Job for the topic. Callers
+// typically map to HTTP 404.
+var ErrNoTopic = errors.New("progress: no active or recent job for topic")
+
+// Subscribe attaches an SSE subscriber to topic.
+//
+//   - Running: write the latest cached event (if any), then live tail
+//     until terminal / client disconnect / Tracker shutdown.
+//   - Retained: write the cached terminal and close.
+//   - Absent: ErrNoTopic.
+//
+// Late subscribers see only the most recent payload — callers must
+// design events as monotonic snapshots (see package README).
+func (t *Tracker) Subscribe(c echo.Context, topic string) error {
+	// Hold t.mu.RLock across lookup + attach so the (j, subscription)
+	// pair stays consistent — without it, a concurrent Start replacing a
+	// retained entry would have us attach to a stale Job. Lock order:
+	// Tracker.mu → Job.mu.
+	t.mu.RLock()
+	j, ok := t.jobs[topic]
+	if !ok {
+		t.mu.RUnlock()
+		return ErrNoTopic
+	}
+	if hook := t.attachHookForTest; hook != nil {
+		hook()
+	}
+	ch, replay, hasReplay, isRetained := t.attach(j)
+	t.mu.RUnlock()
+
+	sse.WriteSSEHeaders(c, t.lc)
+
+	if hasReplay {
+		if err := sse.WriteSSEEvent(c, replay, t.heartbeat, t.lc); err != nil {
+			if !isRetained {
+				t.unsubscribe(j, ch)
+			}
+			return err
+		}
+	}
+
+	if isRetained {
+		return nil
+	}
+
+	return t.runLiveLoop(c, j, ch)
+}
+
+// attach snapshots j.last and (if not terminal) registers a fresh fan-out
+// channel under j.mu. The atomic snapshot+register prevents a concurrent
+// Publish from being missed: any Publish after this point reaches the
+// channel via latest-wins fan-out.
+func (t *Tracker) attach(j *Job) (ch chan any, replay any, hasReplay bool, isRetained bool) {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+
+	replay = j.last
+	hasReplay = j.hasLast
+
+	if j.done {
+		return nil, replay, hasReplay, true
+	}
+
+	ch = make(chan any, subscriberChanBuffer)
+	j.subscribers[ch] = struct{}{}
+	return ch, replay, hasReplay, false
+}
+
+// unsubscribe is idempotent against Finish, which also removes + closes.
+func (t *Tracker) unsubscribe(j *Job, ch chan any) {
+	j.mu.Lock()
+	if _, ok := j.subscribers[ch]; ok {
+		delete(j.subscribers, ch)
+		close(ch)
+	}
+	j.mu.Unlock()
+}
+
+func (t *Tracker) runLiveLoop(c echo.Context, j *Job, ch chan any) error {
+	defer t.unsubscribe(j, ch)
+
+	heartbeat := time.NewTicker(t.heartbeat)
+	defer heartbeat.Stop()
+
+	reqCtx := c.Request().Context()
+	for {
+		select {
+		case payload, open := <-ch:
+			if !open {
+				// Finish closed the channel as a wake-up signal; the
+				// terminal payload lives in j.last (Finish writes it
+				// under j.mu before closing). Even if the buffer carried
+				// a pending snapshot, the terminal is separately read
+				// from j.last after the close signal, so it is never at
+				// the mercy of fan-out drops.
+				j.mu.Lock()
+				var terminal any
+				hasTerminal := j.done && j.hasLast
+				if hasTerminal {
+					terminal = j.last
+				}
+				j.mu.Unlock()
+				if hasTerminal {
+					return sse.WriteSSEEvent(c, terminal, t.heartbeat, t.lc)
+				}
+				return nil
+			}
+			if err := sse.WriteSSEEvent(c, payload, t.heartbeat, t.lc); err != nil {
+				return err
+			}
+
+		case <-heartbeat.C:
+			if err := sse.WriteHeartbeat(c, t.heartbeat, t.lc); err != nil {
+				return err
+			}
+
+		case <-reqCtx.Done():
+			return nil
+		case <-t.ctx.Done():
+			return nil
+		}
+	}
+}

--- a/pkg/sse/progress/subscribe.go
+++ b/pkg/sse/progress/subscribe.go
@@ -43,14 +43,20 @@ func (t *Tracker) Subscribe(c echo.Context, topic string) error {
 	ch, replay, hasReplay, isRetained := t.attach(j)
 	t.mu.RUnlock()
 
-	sse.WriteSSEHeaders(c, t.lc)
+	if err := sse.WriteSSEHeaders(c, t.heartbeat, t.lc); err != nil {
+		if !isRetained {
+			t.unsubscribe(j, ch)
+		}
+		return err
+	}
 
 	if hasReplay {
 		if err := sse.WriteSSEEvent(c, replay, t.heartbeat, t.lc); err != nil {
+			t.lc.Errorf("sse: failed to write replay event: %v", err)
 			if !isRetained {
 				t.unsubscribe(j, ch)
 			}
-			return err
+			return nil
 		}
 	}
 
@@ -116,17 +122,21 @@ func (t *Tracker) runLiveLoop(c echo.Context, j *Job, ch chan any) error {
 				}
 				j.mu.Unlock()
 				if hasTerminal {
-					return sse.WriteSSEEvent(c, terminal, t.heartbeat, t.lc)
+					if err := sse.WriteSSEEvent(c, terminal, t.heartbeat, t.lc); err != nil {
+						t.lc.Errorf("sse: failed to write terminal event: %v", err)
+					}
 				}
 				return nil
 			}
 			if err := sse.WriteSSEEvent(c, payload, t.heartbeat, t.lc); err != nil {
-				return err
+				t.lc.Errorf("sse: failed to write event: %v", err)
+				return nil
 			}
 
 		case <-heartbeat.C:
 			if err := sse.WriteHeartbeat(c, t.heartbeat, t.lc); err != nil {
-				return err
+				t.lc.Warnf("sse: heartbeat write failed: %v", err)
+				return nil
 			}
 
 		case <-reqCtx.Done():

--- a/pkg/sse/progress/subscribe_test.go
+++ b/pkg/sse/progress/subscribe_test.go
@@ -1,0 +1,295 @@
+//
+// Copyright (C) 2026 IOTech Ltd
+//
+
+package progress
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// flushableRecorder wraps httptest.ResponseRecorder with http.Flusher
+// and a no-op SetWriteDeadline (httptest's buffer never blocks, so the
+// production deadline check has nothing to enforce; implementing it lets
+// http.ResponseController succeed without forcing a tolerance branch
+// into pkg/sse/utils.go).
+type flushableRecorder struct {
+	*httptest.ResponseRecorder
+	flushes int
+	mu      sync.Mutex
+}
+
+func (f *flushableRecorder) Flush() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.flushes++
+	f.ResponseRecorder.Flush()
+}
+
+func (f *flushableRecorder) SetWriteDeadline(_ time.Time) error { return nil }
+
+func newSubscribeFixture(t *testing.T) (*flushableRecorder, echo.Context, context.CancelFunc) {
+	t.Helper()
+	rec := &flushableRecorder{ResponseRecorder: httptest.NewRecorder()}
+	reqCtx, cancel := context.WithCancel(context.Background())
+	req := httptest.NewRequest(http.MethodGet, "/sse", nil).WithContext(reqCtx)
+	e := echo.New()
+	c := e.NewContext(req, rec)
+	return rec, c, cancel
+}
+
+func TestSubscribe_ReturnsErrNoTopic_WhenTopicMissing(t *testing.T) {
+	tr := New(context.Background(), time.Second, time.Second, newTestLogger(t))
+	_, c, cancel := newSubscribeFixture(t)
+	defer cancel()
+
+	err := tr.Subscribe(c, "never-started")
+	assert.True(t, errors.Is(err, ErrNoTopic), "expected ErrNoTopic, got %v", err)
+}
+
+// readSSEEvents parses `data: <json>\n\n` frames from body; heartbeats
+// (`:\n\n`) are skipped.
+func readSSEEvents(t *testing.T, body string) []string {
+	t.Helper()
+	var events []string
+	scanner := bufio.NewScanner(strings.NewReader(body))
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, "data: ") {
+			events = append(events, strings.TrimPrefix(line, "data: "))
+		}
+	}
+	require.NoError(t, scanner.Err())
+	return events
+}
+
+func TestSubscribe_RunningJob_DeliversLiveEvents(t *testing.T) {
+	tr := New(context.Background(), time.Second, 5*time.Second, newTestLogger(t))
+	job, _ := tr.Start("topic-a")
+
+	rec, c, cancelReq := newSubscribeFixture(t)
+	subscribeDone := make(chan error, 1)
+	go func() {
+		subscribeDone <- tr.Subscribe(c, "topic-a")
+	}()
+
+	time.Sleep(20 * time.Millisecond) // let attach happen
+
+	job.Publish(map[string]any{"progress": 50, "message": "halfway"})
+	job.Finish(map[string]any{"progress": 100, "message": "done"})
+
+	select {
+	case err := <-subscribeDone:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		cancelReq()
+		t.Fatal("Subscribe did not exit after Finish")
+	}
+
+	events := readSSEEvents(t, rec.Body.String())
+	require.GreaterOrEqual(t, len(events), 2)
+	assert.Contains(t, events[len(events)-1], `"progress":100`)
+
+	assert.Equal(t, "text/event-stream", rec.Header().Get(echo.HeaderContentType))
+	assert.Equal(t, "no-cache", rec.Header().Get("Cache-Control"))
+	assert.Equal(t, "keep-alive", rec.Header().Get("Connection"))
+}
+
+func TestSubscribe_LateSubscriberSeesOnlyLatest(t *testing.T) {
+	// Cache-last semantics: late subscribers replay only the most recent
+	// event. Intermediate publishes are coalesced — callers must design
+	// events as monotonic snapshots (see package README "Scope").
+	tr := New(context.Background(), time.Second, 5*time.Second, newTestLogger(t))
+	job, _ := tr.Start("topic-a")
+
+	job.Publish(map[string]any{"progress": 10, "message": "step 1"})
+	job.Publish(map[string]any{"progress": 30, "message": "step 2"})
+	job.Publish(map[string]any{"progress": 50, "message": "step 3"})
+
+	rec, c, cancelReq := newSubscribeFixture(t)
+	subscribeDone := make(chan error, 1)
+	go func() { subscribeDone <- tr.Subscribe(c, "topic-a") }()
+
+	time.Sleep(50 * time.Millisecond)
+	cancelReq()
+	select {
+	case <-subscribeDone:
+	case <-time.After(time.Second):
+		t.Fatal("Subscribe did not exit on request cancellation")
+	}
+
+	events := readSSEEvents(t, rec.Body.String())
+	require.GreaterOrEqual(t, len(events), 1, "got: %v", events)
+	assert.Contains(t, events[0], `"progress":50`)
+	for _, e := range events {
+		assert.NotContains(t, e, `"progress":10`, "older snapshot must not appear: %s", e)
+		assert.NotContains(t, e, `"progress":30`, "older snapshot must not appear: %s", e)
+	}
+}
+
+func TestSubscribe_RetainedReplay_WritesTerminalAndCloses(t *testing.T) {
+	tr := New(context.Background(), 5*time.Second, 5*time.Second, newTestLogger(t))
+	job, _ := tr.Start("topic-a")
+	job.Publish(map[string]any{"progress": 0, "message": "started"})
+	job.Publish(map[string]any{"progress": 50, "message": "halfway"})
+	job.Finish(map[string]any{"progress": 100, "message": "done"})
+
+	rec, c, cancelReq := newSubscribeFixture(t)
+	defer cancelReq()
+
+	subscribeDone := make(chan error, 1)
+	go func() { subscribeDone <- tr.Subscribe(c, "topic-a") }()
+
+	select {
+	case err := <-subscribeDone:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("Subscribe did not return promptly on retained replay")
+	}
+
+	events := readSSEEvents(t, rec.Body.String())
+	require.Len(t, events, 1, "expected only the cached terminal, got: %v", events)
+	assert.Contains(t, events[0], `"progress":100`)
+}
+
+func TestSubscribe_RetainedReplay_FinishWithoutPriorPublish(t *testing.T) {
+	// Finish without any preceding Publish: Finish unconditionally sets
+	// hasLast=true with the terminal payload, so a late subscriber on the
+	// retained entry must still see exactly one frame (the terminal).
+	tr := New(context.Background(), 5*time.Second, 5*time.Second, newTestLogger(t))
+	job, _ := tr.Start("topic-a")
+	job.Finish(map[string]any{"progress": 100, "message": "done"})
+
+	rec, c, cancelReq := newSubscribeFixture(t)
+	defer cancelReq()
+
+	subscribeDone := make(chan error, 1)
+	go func() { subscribeDone <- tr.Subscribe(c, "topic-a") }()
+
+	select {
+	case err := <-subscribeDone:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("Subscribe did not return promptly on retained replay")
+	}
+
+	events := readSSEEvents(t, rec.Body.String())
+	require.Len(t, events, 1, "expected the terminal frame, got: %v", events)
+	assert.Contains(t, events[0], `"progress":100`)
+}
+
+func TestSubscribe_LiveEventsAfterReplay(t *testing.T) {
+	// Verify the seam: the latest cached event replays first, then live
+	// publishes follow in order, ending with the terminal.
+	tr := New(context.Background(), time.Second, 5*time.Second, newTestLogger(t))
+	job, _ := tr.Start("topic-a")
+
+	job.Publish(map[string]any{"progress": 10, "message": "history-1"})
+	job.Publish(map[string]any{"progress": 20, "message": "history-2"})
+
+	rec, c, cancelReq := newSubscribeFixture(t)
+	subscribeDone := make(chan error, 1)
+	go func() { subscribeDone <- tr.Subscribe(c, "topic-a") }()
+
+	time.Sleep(50 * time.Millisecond) // let replay drain
+
+	job.Publish(map[string]any{"progress": 30, "message": "live-1"})
+	job.Finish(map[string]any{"progress": 100, "message": "done"})
+
+	select {
+	case err := <-subscribeDone:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		cancelReq()
+		t.Fatal("Subscribe did not exit after Finish")
+	}
+
+	events := readSSEEvents(t, rec.Body.String())
+	require.GreaterOrEqual(t, len(events), 2, "got: %v", events)
+	// Replay must be the most recent pre-subscribe payload (progress=20),
+	// not progress=10 (coalesced away).
+	assert.Contains(t, events[0], `"progress":20`)
+	for _, e := range events {
+		assert.NotContains(t, e, `"progress":10}`, "older snapshot must not appear: %s", e)
+	}
+	// Terminal is last.
+	assert.Contains(t, events[len(events)-1], `"progress":100`)
+}
+
+func TestSubscribe_Heartbeat_EmittedOnIdleStream(t *testing.T) {
+	tr := New(context.Background(), time.Second, 25*time.Millisecond, newTestLogger(t))
+	_, _ = tr.Start("topic-a")
+
+	rec, c, cancelReq := newSubscribeFixture(t)
+
+	subscribeDone := make(chan error, 1)
+	go func() { subscribeDone <- tr.Subscribe(c, "topic-a") }()
+
+	// Wait for ≥1 heartbeat, then cancel and read body only after
+	// the subscribe goroutine has fully exited (avoid racing on
+	// rec.Body's *bytes.Buffer).
+	time.Sleep(80 * time.Millisecond)
+	cancelReq()
+	select {
+	case <-subscribeDone:
+	case <-time.After(time.Second):
+		t.Fatal("Subscribe did not exit on cancel")
+	}
+
+	assert.Contains(t, rec.Body.String(), ":\n\n", "expected heartbeat frame")
+}
+
+func TestSubscribe_ExitsOnRequestCancellation(t *testing.T) {
+	tr := New(context.Background(), time.Second, 5*time.Second, newTestLogger(t))
+	_, _ = tr.Start("topic-a")
+
+	_, c, cancelReq := newSubscribeFixture(t)
+
+	subscribeDone := make(chan error, 1)
+	go func() { subscribeDone <- tr.Subscribe(c, "topic-a") }()
+
+	time.Sleep(20 * time.Millisecond)
+	cancelReq()
+
+	select {
+	case err := <-subscribeDone:
+		assert.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("Subscribe did not exit promptly on request cancel")
+	}
+}
+
+func TestSubscribe_ExitsOnTrackerShutdown(t *testing.T) {
+	parentCtx, cancelTracker := context.WithCancel(context.Background())
+	tr := New(parentCtx, time.Second, 5*time.Second, newTestLogger(t))
+	_, _ = tr.Start("topic-a")
+
+	_, c, cancelReq := newSubscribeFixture(t)
+	defer cancelReq()
+
+	subscribeDone := make(chan error, 1)
+	go func() { subscribeDone <- tr.Subscribe(c, "topic-a") }()
+
+	time.Sleep(20 * time.Millisecond)
+	cancelTracker()
+
+	select {
+	case err := <-subscribeDone:
+		assert.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("Subscribe did not exit on tracker shutdown")
+	}
+}

--- a/pkg/sse/progress/subscribe_test.go
+++ b/pkg/sse/progress/subscribe_test.go
@@ -220,10 +220,13 @@ func TestSubscribe_LiveEventsAfterReplay(t *testing.T) {
 	events := readSSEEvents(t, rec.Body.String())
 	require.GreaterOrEqual(t, len(events), 2, "got: %v", events)
 	// Replay must be the most recent pre-subscribe payload (progress=20),
-	// not progress=10 (coalesced away).
+	// not progress=10 (coalesced away). Match on the unique message
+	// rather than `"progress":10}` — the latter depends on `progress`
+	// being the last JSON field, which only holds while it sorts last
+	// alphabetically among the keys (json.Marshal sorts map keys).
 	assert.Contains(t, events[0], `"progress":20`)
 	for _, e := range events {
-		assert.NotContains(t, e, `"progress":10}`, "older snapshot must not appear: %s", e)
+		assert.NotContains(t, e, `"history-1"`, "older snapshot must not appear: %s", e)
 	}
 	// Terminal is last.
 	assert.Contains(t, events[len(events)-1], `"progress":100`)

--- a/pkg/sse/progress/tracker.go
+++ b/pkg/sse/progress/tracker.go
@@ -1,0 +1,140 @@
+//
+// Copyright (C) 2026 IOTech Ltd
+//
+
+package progress
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/IOTechSystems/go-mod-edge-utils/v2/pkg/log"
+)
+
+const (
+	// subscriberChanBuffer is the per-subscriber channel size. Sized to 1
+	// because Publish uses latest-wins semantics: a slow subscriber's
+	// pending stale payload is drained and replaced by the newer one, so
+	// the channel always carries the most recent state. Larger buffers
+	// would queue intermediate snapshots that callers should treat as
+	// already superseded (see README "Scope").
+	subscriberChanBuffer = 1
+
+	defaultRetention = 30 * time.Second
+	defaultHeartbeat = 30 * time.Second
+)
+
+// Tracker is a per-service registry of in-flight and recently-finished
+// Jobs, keyed by topic. See README for the API and the Start vs
+// StartOrJoin selection rule.
+type Tracker struct {
+	mu        sync.RWMutex
+	jobs      map[string]*Job
+	retention time.Duration
+	heartbeat time.Duration
+	ctx       context.Context
+	cancel    context.CancelFunc
+	lc        log.Logger
+
+	// attachHookForTest is invoked by Subscribe between registry lookup
+	// and attach, while Tracker.mu (read) is still held. Tests only.
+	attachHookForTest func()
+}
+
+// New constructs a Tracker bound to ctx. Zero or negative durations use
+// 30s defaults. Cancelling ctx wakes all cleanup goroutines.
+func New(ctx context.Context, retention, heartbeat time.Duration, lc log.Logger) *Tracker {
+	if retention <= 0 {
+		retention = defaultRetention
+	}
+	if heartbeat <= 0 {
+		heartbeat = defaultHeartbeat
+	}
+
+	ctx, cancel := context.WithCancel(ctx)
+	return &Tracker{
+		jobs:      make(map[string]*Job),
+		retention: retention,
+		heartbeat: heartbeat,
+		ctx:       ctx,
+		cancel:    cancel,
+		lc:        lc,
+	}
+}
+
+// Start is the trigger-driven entry. Running entry → join; retained
+// terminal → discard and create fresh; absent → create.
+//
+// The retained-discard case is the load-bearing difference vs
+// StartOrJoin: a new trigger after the previous run finished must
+// produce a fresh run, not silently observe the prior terminal.
+func (t *Tracker) Start(topic string) (job *Job, isNew bool) {
+	t.mu.Lock()
+	if existing, ok := t.jobs[topic]; ok {
+		if !existing.isTerminal() {
+			t.mu.Unlock()
+			return existing, false
+		}
+		// Retained — replace. The previous Job's cleanup goroutine sees
+		// jobs[topic] != itself in deleteIfIdentity and leaves us alone.
+	}
+	j := newJob()
+	t.jobs[topic] = j
+	t.mu.Unlock()
+
+	go t.watchAndCleanup(topic, j)
+	return j, true
+}
+
+// StartOrJoin is the subscriber-driven entry. Any existing entry —
+// running or retained terminal — is reused; absent → create.
+//
+// The retained-reuse case is the load-bearing difference vs Start: late
+// subscribers on a compute-once flow observe the cached terminal
+// instead of retriggering work.
+func (t *Tracker) StartOrJoin(topic string) (job *Job, isNew bool) {
+	t.mu.Lock()
+	if existing, ok := t.jobs[topic]; ok {
+		t.mu.Unlock()
+		return existing, false
+	}
+
+	j := newJob()
+	t.jobs[topic] = j
+	t.mu.Unlock()
+
+	go t.watchAndCleanup(topic, j)
+	return j, true
+}
+
+// watchAndCleanup removes jobs[topic] after Finish + retention, or
+// immediately on Tracker shutdown. Both paths gate on an identity check
+// so that a Start replacement (retained → fresh) survives the old Job's
+// cleanup pass.
+func (t *Tracker) watchAndCleanup(topic string, j *Job) {
+	select {
+	case <-j.finished:
+	case <-t.ctx.Done():
+		t.deleteIfIdentity(topic, j)
+		return
+	}
+
+	timer := time.NewTimer(t.retention)
+	defer timer.Stop()
+
+	select {
+	case <-timer.C:
+	case <-t.ctx.Done():
+	}
+
+	t.deleteIfIdentity(topic, j)
+}
+
+func (t *Tracker) deleteIfIdentity(topic string, j *Job) {
+	t.mu.Lock()
+	if t.jobs[topic] == j {
+		delete(t.jobs, topic)
+	}
+	t.mu.Unlock()
+}

--- a/pkg/sse/progress/tracker.go
+++ b/pkg/sse/progress/tracker.go
@@ -28,13 +28,18 @@ const (
 // Tracker is a per-service registry of in-flight and recently-finished
 // Jobs, keyed by topic. See README for the API and the Start vs
 // StartOrJoin selection rule.
+//
+// Tracker holds the caller-supplied ctx directly (no WithCancel wrap):
+// its lifecycle matches the parent, so cancelling the parent wakes
+// every watchAndCleanup goroutine and every in-flight Subscribe loop.
+// If a future use case needs to shut down a Tracker independent of its
+// parent, reintroduce a cancel field + Close() — it isn't needed today.
 type Tracker struct {
 	mu        sync.RWMutex
 	jobs      map[string]*Job
 	retention time.Duration
 	heartbeat time.Duration
 	ctx       context.Context
-	cancel    context.CancelFunc
 	lc        log.Logger
 
 	// attachHookForTest is invoked by Subscribe between registry lookup
@@ -52,13 +57,11 @@ func New(ctx context.Context, retention, heartbeat time.Duration, lc log.Logger)
 		heartbeat = defaultHeartbeat
 	}
 
-	ctx, cancel := context.WithCancel(ctx)
 	return &Tracker{
 		jobs:      make(map[string]*Job),
 		retention: retention,
 		heartbeat: heartbeat,
 		ctx:       ctx,
-		cancel:    cancel,
 		lc:        lc,
 	}
 }

--- a/pkg/sse/progress/tracker_test.go
+++ b/pkg/sse/progress/tracker_test.go
@@ -1,0 +1,247 @@
+//
+// Copyright (C) 2026 IOTech Ltd
+//
+
+package progress
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/IOTechSystems/go-mod-edge-utils/v2/pkg/log"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestLogger(_ *testing.T) log.Logger {
+	return log.NewNopeLogger()
+}
+
+func TestNew_DefaultsAppliedForZeroOrNegative(t *testing.T) {
+	tr := New(context.Background(), 0, -1, newTestLogger(t))
+	require.NotNil(t, tr)
+	assert.Equal(t, defaultRetention, tr.retention)
+	assert.Equal(t, defaultHeartbeat, tr.heartbeat)
+	assert.NotNil(t, tr.jobs)
+}
+
+func TestNew_HonoursPositiveDurations(t *testing.T) {
+	tr := New(context.Background(), 7*time.Second, 3*time.Second, newTestLogger(t))
+	assert.Equal(t, 7*time.Second, tr.retention)
+	assert.Equal(t, 3*time.Second, tr.heartbeat)
+}
+
+// ---------- Start ----------
+
+func TestTracker_Start_RegistersJobWhenAbsent(t *testing.T) {
+	tr := New(context.Background(), time.Second, time.Second, newTestLogger(t))
+
+	job, isNew := tr.Start("topic-a")
+
+	require.NotNil(t, job)
+	assert.True(t, isNew)
+	tr.mu.RLock()
+	stored, ok := tr.jobs["topic-a"]
+	tr.mu.RUnlock()
+	require.True(t, ok)
+	assert.Same(t, job, stored)
+}
+
+func TestTracker_Start_JoinsRunningEntry(t *testing.T) {
+	tr := New(context.Background(), time.Second, time.Second, newTestLogger(t))
+
+	first, isNewFirst := tr.Start("topic-a")
+	second, isNewSecond := tr.Start("topic-a") // first still running
+
+	assert.True(t, isNewFirst)
+	assert.False(t, isNewSecond)
+	assert.Same(t, first, second, "running entry must be joined, not replaced")
+}
+
+func TestTracker_Start_ReplacesRetainedEntryWithFresh(t *testing.T) {
+	// Load-bearing vs StartOrJoin: a trigger after retention must run
+	// fresh, not observe the prior terminal.
+	tr := New(context.Background(), 30*time.Second, time.Second, newTestLogger(t))
+
+	first, _ := tr.Start("topic-a")
+	first.Finish("ok")
+
+	second, isNew := tr.Start("topic-a")
+	assert.NotSame(t, first, second)
+	assert.True(t, isNew)
+
+	tr.mu.RLock()
+	stored := tr.jobs["topic-a"]
+	tr.mu.RUnlock()
+	assert.Same(t, second, stored)
+}
+
+// ---------- StartOrJoin ----------
+
+func TestTracker_StartOrJoin_CreatesWhenAbsent(t *testing.T) {
+	tr := New(context.Background(), time.Second, time.Second, newTestLogger(t))
+
+	job, isNew := tr.StartOrJoin("topic-a")
+	require.NotNil(t, job)
+	assert.True(t, isNew)
+}
+
+func TestTracker_StartOrJoin_ReusesRunning(t *testing.T) {
+	tr := New(context.Background(), time.Second, time.Second, newTestLogger(t))
+
+	first, isNewFirst := tr.StartOrJoin("topic-a")
+	second, isNewSecond := tr.StartOrJoin("topic-a")
+
+	assert.True(t, isNewFirst)
+	assert.False(t, isNewSecond)
+	assert.Same(t, first, second)
+}
+
+func TestTracker_StartOrJoin_ReusesRetained(t *testing.T) {
+	// Load-bearing vs Start: late subscribers on a compute-once flow
+	// must observe the cached terminal, not retrigger.
+	tr := New(context.Background(), 30*time.Second, time.Second, newTestLogger(t))
+
+	first, _ := tr.StartOrJoin("topic-a")
+	first.Finish("ok")
+
+	second, isNew := tr.StartOrJoin("topic-a")
+	assert.Same(t, first, second)
+	assert.False(t, isNew)
+}
+
+func TestTracker_StartOrJoin_ConcurrentRaceLandsOnSingleJob(t *testing.T) {
+	tr := New(context.Background(), time.Second, time.Second, newTestLogger(t))
+
+	const n = 32
+	var (
+		wg      sync.WaitGroup
+		results = make([]*Job, n)
+		newFlag = make([]bool, n)
+	)
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func(i int) {
+			defer wg.Done()
+			j, isNew := tr.StartOrJoin("topic-race")
+			results[i] = j
+			newFlag[i] = isNew
+		}(i)
+	}
+	wg.Wait()
+
+	newCount := 0
+	for _, b := range newFlag {
+		if b {
+			newCount++
+		}
+	}
+	assert.Equal(t, 1, newCount)
+	for i := 1; i < n; i++ {
+		assert.Same(t, results[0], results[i])
+	}
+}
+
+func TestTracker_Start_ConcurrentRaceLandsOnSingleJob(t *testing.T) {
+	tr := New(context.Background(), time.Second, time.Second, newTestLogger(t))
+
+	const n = 32
+	var (
+		wg      sync.WaitGroup
+		results = make([]*Job, n)
+		newFlag = make([]bool, n)
+	)
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func(i int) {
+			defer wg.Done()
+			j, isNew := tr.Start("topic-race")
+			results[i] = j
+			newFlag[i] = isNew
+		}(i)
+	}
+	wg.Wait()
+
+	newCount := 0
+	for _, b := range newFlag {
+		if b {
+			newCount++
+		}
+	}
+	assert.Equal(t, 1, newCount)
+	for i := 1; i < n; i++ {
+		assert.Same(t, results[0], results[i])
+	}
+}
+
+// ---------- cleanup ----------
+
+func TestTracker_Cleanup_RemovesEntryAfterRetention(t *testing.T) {
+	tr := New(context.Background(), 30*time.Millisecond, time.Second, newTestLogger(t))
+
+	job, _ := tr.Start("topic-a")
+	job.Finish("ok")
+
+	require.Eventually(t, func() bool {
+		tr.mu.RLock()
+		_, ok := tr.jobs["topic-a"]
+		tr.mu.RUnlock()
+		return !ok
+	}, time.Second, 5*time.Millisecond)
+}
+
+func TestTracker_Cleanup_RespectsTrackerContext(t *testing.T) {
+	parentCtx, cancel := context.WithCancel(context.Background())
+	tr := New(parentCtx, 10*time.Second, time.Second, newTestLogger(t))
+
+	job, _ := tr.Start("topic-a")
+	job.Finish("ok")
+
+	cancel()
+
+	require.Eventually(t, func() bool {
+		tr.mu.RLock()
+		_, ok := tr.jobs["topic-a"]
+		tr.mu.RUnlock()
+		return !ok
+	}, time.Second, 5*time.Millisecond)
+}
+
+func TestTracker_Cleanup_IdentityCheckPreservesReplacement(t *testing.T) {
+	// Regression: Start's retained→fresh replacement must not be evicted
+	// by the old Job's cleanup goroutine.
+	tr := New(context.Background(), 20*time.Millisecond, time.Second, newTestLogger(t))
+
+	old, _ := tr.Start("topic-a")
+	old.Finish("old terminal")
+
+	replacement, isNew := tr.Start("topic-a")
+	require.True(t, isNew)
+	assert.NotSame(t, old, replacement)
+
+	time.Sleep(80 * time.Millisecond) // > retention; let old's cleanup fire
+
+	tr.mu.RLock()
+	stored, ok := tr.jobs["topic-a"]
+	tr.mu.RUnlock()
+	require.True(t, ok)
+	assert.Same(t, replacement, stored)
+}
+
+func TestTracker_Cleanup_TrackerCtxCancelBeforeTerminal(t *testing.T) {
+	parentCtx, cancel := context.WithCancel(context.Background())
+	tr := New(parentCtx, 10*time.Second, time.Second, newTestLogger(t))
+
+	_, _ = tr.Start("topic-a") // never terminated
+	cancel()
+
+	require.Eventually(t, func() bool {
+		tr.mu.RLock()
+		_, ok := tr.jobs["topic-a"]
+		tr.mu.RUnlock()
+		return !ok
+	}, time.Second, 5*time.Millisecond)
+}

--- a/pkg/sse/utils.go
+++ b/pkg/sse/utils.go
@@ -1,0 +1,111 @@
+//
+// Copyright (C) 2026 IOTech Ltd
+//
+
+package sse
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/labstack/echo/v4"
+
+	"github.com/IOTechSystems/go-mod-edge-utils/v2/pkg/log"
+)
+
+// WriteSSEHeaders sets the three SSE response headers on c and flushes
+// them immediately so the client sees the text/event-stream content type
+// before any payload arrives. It also runs a one-shot probe verifying
+// that the underlying writer chain exposes SetWriteDeadline; a failure
+// is logged loudly so a misconfigured middleware/wrapper surfaces at
+// stream start rather than as a confusing first-event write error.
+func WriteSSEHeaders(c echo.Context, lc log.Logger) {
+	h := c.Response().Header()
+	h.Set(echo.HeaderContentType, "text/event-stream")
+	h.Set("Cache-Control", "no-cache")
+	h.Set("Connection", "keep-alive")
+	flush(c, lc)
+	probeWriteDeadline(c, lc)
+}
+
+// probeWriteDeadline runs once per stream — right after the SSE headers
+// flush — to surface writer-chain misconfigurations early. Passing the
+// zero time clears any deadline, so a successful probe leaves no
+// lingering side effect; a failure means the per-write deadlines in
+// WriteSSEEvent / WriteHeartbeat will also fail (and terminate the
+// stream), so logging here gives ops the diagnostic earlier than the
+// first event/heartbeat would.
+func probeWriteDeadline(c echo.Context, lc log.Logger) {
+	rc := http.NewResponseController(c.Response().Writer)
+	if err := rc.SetWriteDeadline(time.Time{}); err != nil {
+		lc.Errorf("sse: writer chain does not support SetWriteDeadline — slow-client protection unavailable; check middleware (err=%v)", err)
+	}
+}
+
+// WriteSSEEvent JSON-encodes payload, writes a single SSE data frame, and
+// flushes. A marshal failure is logged and the event is skipped without
+// killing the stream. The returned error signals an underlying write
+// failure (broken pipe, deadline expired, or a missing write-deadline
+// capability — see applyWriteDeadline).
+//
+// writeDeadline bounds the time the underlying connection has to accept
+// the write; pass the same value as the heartbeat interval. The caller's
+// ResponseWriter MUST support http.ResponseController write deadlines
+// (stock Echo + raw net/http does; test fixtures must implement
+// SetWriteDeadline as a no-op).
+func WriteSSEEvent(c echo.Context, payload any, writeDeadline time.Duration, lc log.Logger) error {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		lc.Errorf("sse: failed to marshal SSE payload: %v", err)
+		return nil
+	}
+	if err := applyWriteDeadline(c, writeDeadline, lc); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(c.Response().Writer, "data: %s\n\n", body); err != nil {
+		return err
+	}
+	flush(c, lc)
+	return nil
+}
+
+// WriteHeartbeat writes an SSE heartbeat frame (`:\n\n`) and flushes.
+// Same writeDeadline semantics as WriteSSEEvent.
+func WriteHeartbeat(c echo.Context, writeDeadline time.Duration, lc log.Logger) error {
+	if err := applyWriteDeadline(c, writeDeadline, lc); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprint(c.Response().Writer, ":\n\n"); err != nil {
+		return err
+	}
+	flush(c, lc)
+	return nil
+}
+
+// applyWriteDeadline sets a per-write deadline on the response's
+// underlying connection. Any failure — including http.ErrNotSupported —
+// is treated as fatal so the SSE handler exits instead of writing
+// without slow-client protection. ErrNotSupported indicates the writer
+// (or its wrappers) doesn't expose deadline-setting; the right place to
+// fix that is the writer/middleware, not here.
+func applyWriteDeadline(c echo.Context, d time.Duration, lc log.Logger) error {
+	rc := http.NewResponseController(c.Response().Writer)
+	if err := rc.SetWriteDeadline(time.Now().Add(d)); err != nil {
+		lc.Errorf("sse: failed to set write deadline: %v", err)
+		return err
+	}
+	return nil
+}
+
+// flush emits buffered response bytes to the network. Writers that don't
+// implement http.Flusher get a warn log; SSE streams effectively stall
+// without flushing, but the process continues.
+func flush(c echo.Context, lc log.Logger) {
+	if f, ok := c.Response().Writer.(http.Flusher); ok {
+		f.Flush()
+		return
+	}
+	lc.Warn("sse: ResponseWriter does not support flushing; SSE may stall")
+}

--- a/pkg/sse/utils.go
+++ b/pkg/sse/utils.go
@@ -15,33 +15,28 @@ import (
 	"github.com/IOTechSystems/go-mod-edge-utils/v2/pkg/log"
 )
 
-// WriteSSEHeaders sets the three SSE response headers on c and flushes
-// them immediately so the client sees the text/event-stream content type
-// before any payload arrives. It also runs a one-shot probe verifying
-// that the underlying writer chain exposes SetWriteDeadline; a failure
-// is logged loudly so a misconfigured middleware/wrapper surfaces at
-// stream start rather than as a confusing first-event write error.
-func WriteSSEHeaders(c echo.Context, lc log.Logger) {
+// WriteSSEHeaders applies a write deadline, sets the three SSE response
+// headers on c, and flushes them immediately so the client sees the
+// text/event-stream content type before any payload arrives.
+//
+// The deadline is applied BEFORE the initial flush so the goroutine
+// can't hang on a slow/dead client while writing headers. writeDeadline
+// should match the per-event/heartbeat value (typically the heartbeat
+// interval). A failure to set the deadline is fatal and returned to the
+// caller before any bytes are committed — the caller can then surface a
+// proper 5xx rather than committing 200 and dying on the first event.
+// ErrNotSupported here means the writer chain (middleware/wrappers)
+// doesn't expose SetWriteDeadline; fix the writer, not this code.
+func WriteSSEHeaders(c echo.Context, writeDeadline time.Duration, lc log.Logger) error {
+	if err := applyWriteDeadline(c, writeDeadline, lc); err != nil {
+		return err
+	}
 	h := c.Response().Header()
 	h.Set(echo.HeaderContentType, "text/event-stream")
 	h.Set("Cache-Control", "no-cache")
 	h.Set("Connection", "keep-alive")
 	flush(c, lc)
-	probeWriteDeadline(c, lc)
-}
-
-// probeWriteDeadline runs once per stream — right after the SSE headers
-// flush — to surface writer-chain misconfigurations early. Passing the
-// zero time clears any deadline, so a successful probe leaves no
-// lingering side effect; a failure means the per-write deadlines in
-// WriteSSEEvent / WriteHeartbeat will also fail (and terminate the
-// stream), so logging here gives ops the diagnostic earlier than the
-// first event/heartbeat would.
-func probeWriteDeadline(c echo.Context, lc log.Logger) {
-	rc := http.NewResponseController(c.Response().Writer)
-	if err := rc.SetWriteDeadline(time.Time{}); err != nil {
-		lc.Errorf("sse: writer chain does not support SetWriteDeadline — slow-client protection unavailable; check middleware (err=%v)", err)
-	}
+	return nil
 }
 
 // WriteSSEEvent JSON-encodes payload, writes a single SSE data frame, and

--- a/pkg/sse/utils.go
+++ b/pkg/sse/utils.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 
+	"github.com/IOTechSystems/go-mod-edge-utils/v2/pkg/common"
 	"github.com/IOTechSystems/go-mod-edge-utils/v2/pkg/log"
 )
 
@@ -32,9 +33,9 @@ func WriteSSEHeaders(c echo.Context, writeDeadline time.Duration, lc log.Logger)
 		return err
 	}
 	h := c.Response().Header()
-	h.Set(echo.HeaderContentType, "text/event-stream")
-	h.Set("Cache-Control", "no-cache")
-	h.Set("Connection", "keep-alive")
+	h.Set(echo.HeaderContentType, common.ContentTypeEventStream)
+	h.Set(common.CacheControl, common.NoCache)
+	h.Set(common.Connection, common.KeepAlive)
 	flush(c, lc)
 	return nil
 }

--- a/pkg/sse/utils.go
+++ b/pkg/sse/utils.go
@@ -80,12 +80,20 @@ func WriteHeartbeat(c echo.Context, writeDeadline time.Duration, lc log.Logger) 
 }
 
 // applyWriteDeadline sets a per-write deadline on the response's
-// underlying connection. Any failure — including http.ErrNotSupported —
-// is treated as fatal so the SSE handler exits instead of writing
-// without slow-client protection. ErrNotSupported indicates the writer
-// (or its wrappers) doesn't expose deadline-setting; the right place to
-// fix that is the writer/middleware, not here.
+// underlying connection. A non-positive d would resolve to an
+// immediate/past deadline and fail every subsequent write, so it is
+// defensively replaced with defaultHeartbeatInterval and a Warnf is
+// emitted — exported helpers shouldn't surprise callers with timeouts
+// from arithmetic. Any SetWriteDeadline failure (including
+// http.ErrNotSupported) is treated as fatal so the SSE handler exits
+// instead of writing without slow-client protection; ErrNotSupported
+// indicates the writer (or its wrappers) doesn't expose
+// deadline-setting, which is a middleware fix, not a runtime one.
 func applyWriteDeadline(c echo.Context, d time.Duration, lc log.Logger) error {
+	if d <= 0 {
+		lc.Warnf("sse: non-positive write deadline %v; using default %v", d, defaultHeartbeatInterval)
+		d = defaultHeartbeatInterval
+	}
 	rc := http.NewResponseController(c.Response().Writer)
 	if err := rc.SetWriteDeadline(time.Now().Add(d)); err != nil {
 		lc.Errorf("sse: failed to set write deadline: %v", err)

--- a/pkg/sse/utils_test.go
+++ b/pkg/sse/utils_test.go
@@ -1,0 +1,95 @@
+//
+// Copyright (C) 2026 IOTech Ltd
+//
+
+package sse
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/IOTechSystems/go-mod-edge-utils/v2/pkg/log"
+)
+
+// captureLogger records Errorf calls so the probe's diagnostic log can
+// be asserted. Other levels are inherited from NopeLogger.
+type captureLogger struct {
+	log.NopeLogger
+	mu      sync.Mutex
+	errorfs []string
+}
+
+func (c *captureLogger) Errorf(msg string, args ...any) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.errorfs = append(c.errorfs, fmt.Sprintf(msg, args...))
+}
+
+func (c *captureLogger) snapshotErrorfs() []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]string, len(c.errorfs))
+	copy(out, c.errorfs)
+	return out
+}
+
+// deadlineCapableRecorder is a httptest.ResponseRecorder that also
+// satisfies http.ResponseController's SetWriteDeadline (as a no-op),
+// exercising the "writer supports deadlines" probe branch.
+type deadlineCapableRecorder struct {
+	*httptest.ResponseRecorder
+}
+
+func (d *deadlineCapableRecorder) SetWriteDeadline(_ time.Time) error { return nil }
+
+func newProbeContext(rw http.ResponseWriter) echo.Context {
+	req := httptest.NewRequest(http.MethodGet, "/sse", nil)
+	return echo.New().NewContext(req, rw)
+}
+
+func TestProbeWriteDeadline_SilentWhenSupported(t *testing.T) {
+	rec := &deadlineCapableRecorder{ResponseRecorder: httptest.NewRecorder()}
+	lc := &captureLogger{}
+
+	probeWriteDeadline(newProbeContext(rec), lc)
+
+	assert.Empty(t, lc.snapshotErrorfs(),
+		"a writer that supports SetWriteDeadline must not trigger the probe log")
+}
+
+func TestProbeWriteDeadline_LogsWhenUnsupported(t *testing.T) {
+	// Plain httptest.ResponseRecorder supports Flush but does NOT support
+	// SetWriteDeadline — http.ResponseController returns ErrNotSupported.
+	rec := httptest.NewRecorder()
+	lc := &captureLogger{}
+
+	probeWriteDeadline(newProbeContext(rec), lc)
+
+	errs := lc.snapshotErrorfs()
+	if assert.Len(t, errs, 1, "exactly one probe Errorf is expected when SetWriteDeadline is unsupported") {
+		assert.Contains(t, errs[0], "SetWriteDeadline",
+			"probe log must name the missing capability so ops can diagnose")
+	}
+}
+
+func TestWriteSSEHeaders_InvokesProbe(t *testing.T) {
+	// Smoke test: WriteSSEHeaders must drive the probe so the diagnostic
+	// fires at stream start regardless of which SSE entry point is in use.
+	rec := httptest.NewRecorder()
+	lc := &captureLogger{}
+
+	WriteSSEHeaders(newProbeContext(rec), lc)
+
+	errs := lc.snapshotErrorfs()
+	if assert.Len(t, errs, 1, "WriteSSEHeaders must invoke the probe exactly once") {
+		assert.Contains(t, strings.ToLower(errs[0]), "setwritedeadline")
+	}
+}

--- a/pkg/sse/utils_test.go
+++ b/pkg/sse/utils_test.go
@@ -8,19 +8,20 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/IOTechSystems/go-mod-edge-utils/v2/pkg/log"
 )
 
-// captureLogger records Errorf calls so the probe's diagnostic log can
-// be asserted. Other levels are inherited from NopeLogger.
+// captureLogger records Errorf calls so the diagnostic log emitted by
+// applyWriteDeadline (which WriteSSEHeaders delegates to) can be
+// asserted. Other levels are inherited from NopeLogger.
 type captureLogger struct {
 	log.NopeLogger
 	mu      sync.Mutex
@@ -43,53 +44,43 @@ func (c *captureLogger) snapshotErrorfs() []string {
 
 // deadlineCapableRecorder is a httptest.ResponseRecorder that also
 // satisfies http.ResponseController's SetWriteDeadline (as a no-op),
-// exercising the "writer supports deadlines" probe branch.
+// exercising the "writer supports deadlines" branch.
 type deadlineCapableRecorder struct {
 	*httptest.ResponseRecorder
 }
 
 func (d *deadlineCapableRecorder) SetWriteDeadline(_ time.Time) error { return nil }
 
-func newProbeContext(rw http.ResponseWriter) echo.Context {
+func newSSEContext(rw http.ResponseWriter) echo.Context {
 	req := httptest.NewRequest(http.MethodGet, "/sse", nil)
 	return echo.New().NewContext(req, rw)
 }
 
-func TestProbeWriteDeadline_SilentWhenSupported(t *testing.T) {
+func TestWriteSSEHeaders_SucceedsWhenDeadlineSupported(t *testing.T) {
 	rec := &deadlineCapableRecorder{ResponseRecorder: httptest.NewRecorder()}
 	lc := &captureLogger{}
 
-	probeWriteDeadline(newProbeContext(rec), lc)
+	err := WriteSSEHeaders(newSSEContext(rec), time.Second, lc)
 
-	assert.Empty(t, lc.snapshotErrorfs(),
-		"a writer that supports SetWriteDeadline must not trigger the probe log")
+	require.NoError(t, err, "writer supports SetWriteDeadline; WriteSSEHeaders must succeed")
+	assert.Empty(t, lc.snapshotErrorfs(), "successful path must not log Errorf")
+	assert.Equal(t, "text/event-stream", rec.Header().Get(echo.HeaderContentType))
+	assert.Equal(t, "no-cache", rec.Header().Get("Cache-Control"))
+	assert.Equal(t, "keep-alive", rec.Header().Get("Connection"))
 }
 
-func TestProbeWriteDeadline_LogsWhenUnsupported(t *testing.T) {
+func TestWriteSSEHeaders_FailsWhenDeadlineUnsupported(t *testing.T) {
 	// Plain httptest.ResponseRecorder supports Flush but does NOT support
 	// SetWriteDeadline — http.ResponseController returns ErrNotSupported.
 	rec := httptest.NewRecorder()
 	lc := &captureLogger{}
 
-	probeWriteDeadline(newProbeContext(rec), lc)
+	err := WriteSSEHeaders(newSSEContext(rec), time.Second, lc)
 
+	require.Error(t, err, "missing SetWriteDeadline must be surfaced as a returned error")
 	errs := lc.snapshotErrorfs()
-	if assert.Len(t, errs, 1, "exactly one probe Errorf is expected when SetWriteDeadline is unsupported") {
-		assert.Contains(t, errs[0], "SetWriteDeadline",
-			"probe log must name the missing capability so ops can diagnose")
-	}
-}
-
-func TestWriteSSEHeaders_InvokesProbe(t *testing.T) {
-	// Smoke test: WriteSSEHeaders must drive the probe so the diagnostic
-	// fires at stream start regardless of which SSE entry point is in use.
-	rec := httptest.NewRecorder()
-	lc := &captureLogger{}
-
-	WriteSSEHeaders(newProbeContext(rec), lc)
-
-	errs := lc.snapshotErrorfs()
-	if assert.Len(t, errs, 1, "WriteSSEHeaders must invoke the probe exactly once") {
-		assert.Contains(t, strings.ToLower(errs[0]), "setwritedeadline")
+	if assert.Len(t, errs, 1, "exactly one diagnostic Errorf is expected when SetWriteDeadline is unsupported") {
+		assert.Contains(t, errs[0], "write deadline",
+			"diagnostic must name the failed capability so ops can diagnose")
 	}
 }


### PR DESCRIPTION
The existing pkg/sse model is subscriber-driven — events emitted before the first SSE client connects are dropped, and finished streams are not retained for late subscribers.

This package adds a publisher-driven Tracker that fixes both:
  - blind-spot: lastEvent cached on each Publish, pre-loaded on attach so late subscribers see current state.
  - retention: finished Jobs held in the registry for a configurable window so a GET after the POST trigger still receives the terminal event.

Also refactors pkg/sse/handler.go to share new write helpers (WriteSSEHeaders / WriteSSEEvent / WriteHeartbeat). WriteSSEHeaders applies a write deadline before its initial flush, so a missing SetWriteDeadline capability (or a slow client during header flush) surfaces as a clean error before any bytes are committed — Subscribe / handleSSE can then return a proper 5xx instead of committing 200 and dying on the first event. Per-event/heartbeat writes refresh the deadline; failures after headers are committed are logged and the loop returns nil (consistent across both entry points).