### PR TITLE
EDX-7089 Include details in SendRequest error message

### DIFF
--- a/pkg/models/base.go
+++ b/pkg/models/base.go
@@ -56,9 +56,9 @@ type ErrorDetail struct {
 }
 
 // ErrorResponse defines an error response that may include actionable details.
-// This is compatible with services (e.g., alarm service) that return a "details"
-// array alongside the top-level "message". It also handles standard BaseResponse
-// format (message-only) since the Details field is optional.
+// Compatible with services that return a top-level "message" and optional
+// "details" array. When unmarshalling, additional BaseResponse fields
+// (e.g. apiVersion, requestId, statusCode) are ignored.
 type ErrorResponse struct {
 	Message string        `json:"message,omitempty"`
 	Details []ErrorDetail `json:"details,omitempty"`

--- a/pkg/models/base.go
+++ b/pkg/models/base.go
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2020-2023 IOTech Ltd
+// Copyright (C) 2020-2026 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -48,4 +48,18 @@ func NewBaseResponse(requestId string, message string, statusCode int) BaseRespo
 		Message:     message,
 		StatusCode:  statusCode,
 	}
+}
+
+// ErrorDetail represents a single error detail entry in an ErrorResponse.
+type ErrorDetail struct {
+	Message string `json:"message,omitempty"`
+}
+
+// ErrorResponse defines an error response that may include actionable details.
+// This is compatible with services (e.g., alarm service) that return a "details"
+// array alongside the top-level "message". It also handles standard BaseResponse
+// format (message-only) since the Details field is optional.
+type ErrorResponse struct {
+	Message string        `json:"message,omitempty"`
+	Details []ErrorDetail `json:"details,omitempty"`
 }

--- a/pkg/rest/utils.go
+++ b/pkg/rest/utils.go
@@ -393,16 +393,21 @@ func SendRequest(ctx context.Context, req *http.Request, authInjector interfaces
 	// are appended so callers can surface actionable info.
 	var errResp models.ErrorResponse
 	if json.Unmarshal(bodyBytes, &errResp) == nil {
-		errMsg = errResp.Message
-		if len(errResp.Details) > 0 {
-			var detailMsgs []string
-			for _, d := range errResp.Details {
-				if d.Message != "" {
-					detailMsgs = append(detailMsgs, d.Message)
-				}
+		errMsg = strings.TrimSpace(errResp.Message)
+		detailMsgs := make([]string, 0, len(errResp.Details))
+		for _, d := range errResp.Details {
+			msg := strings.TrimSpace(d.Message)
+			if msg != "" {
+				detailMsgs = append(detailMsgs, msg)
 			}
-			if len(detailMsgs) > 0 {
+		}
+		if errMsg == "" && len(detailMsgs) == 0 {
+			errMsg = string(bodyBytes)
+		} else if len(detailMsgs) > 0 {
+			if errMsg != "" {
 				errMsg += ": " + strings.Join(detailMsgs, "; ")
+			} else {
+				errMsg = strings.Join(detailMsgs, "; ")
 			}
 		}
 	} else {

--- a/pkg/rest/utils.go
+++ b/pkg/rest/utils.go
@@ -387,12 +387,24 @@ func SendRequest(ctx context.Context, req *http.Request, authInjector interfaces
 	}
 
 	var errMsg string
-	var errResp models.BaseResponse
-	// If the bodyBytes can be unmarshalled to BaseResponse DTO, use the BaseResponse.Message field as the error message
-	// Otherwise, use the whole bodyBytes string as the error message
-	baseRespErr := json.Unmarshal(bodyBytes, &errResp)
-	if baseRespErr == nil {
+	// Try to extract the error message and optional details from the response body.
+	// Some services (e.g., alarm service) return an ErrorResponse with a "details"
+	// array alongside the top-level "message". When present, the detail messages
+	// are appended so callers can surface actionable info.
+	var errResp models.ErrorResponse
+	if json.Unmarshal(bodyBytes, &errResp) == nil {
 		errMsg = errResp.Message
+		if len(errResp.Details) > 0 {
+			var detailMsgs []string
+			for _, d := range errResp.Details {
+				if d.Message != "" {
+					detailMsgs = append(detailMsgs, d.Message)
+				}
+			}
+			if len(detailMsgs) > 0 {
+				errMsg += ": " + strings.Join(detailMsgs, "; ")
+			}
+		}
 	} else {
 		errMsg = string(bodyBytes)
 	}


### PR DESCRIPTION
Some backend services (e.g. alarm service) return error responses with a "details" array containing actionable information alongside the top-level "message". Previously, SendRequest only extracted the "message" field via BaseResponse, discarding the details.

Introduce ErrorResponse model with a Details field and update SendRequest to append detail messages to the error string, so callers (e.g. central-ui) can surface the full error context to end users.